### PR TITLE
SSRF の IPv4-mapped IPv6 バイパスを修正

### DIFF
--- a/functions/lib/url-validation.test.ts
+++ b/functions/lib/url-validation.test.ts
@@ -51,6 +51,8 @@ describe('assertSafeUrl', () => {
     expect(() => assertSafeUrl('http://[2001:0:4136:e378:8000:63bf:3fff:fdd2]/')).toThrow(
       'blocked'
     );
+    // :: compressed form (server_high = 0x0000)
+    expect(() => assertSafeUrl('http://[2001::101:8000:63bf:3fff:fdd2]/')).toThrow('blocked');
   });
 
   it('should block IPv4-compatible addresses (deprecated ::/96)', () => {

--- a/functions/lib/url-validation.ts
+++ b/functions/lib/url-validation.ts
@@ -35,7 +35,7 @@ function ipv6MappedToIPv4(bare: string): string | null {
   return `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`;
 }
 
-const BLOCKED_IPV6_PREFIXES = ['::1', 'fc', 'fd', 'fe80', '2002:', '2001:0:'];
+const BLOCKED_IPV6_PREFIXES = ['::1', 'fc', 'fd', 'fe80', '2002:', '2001:'];
 
 function isBlockedIPv6(hostname: string): boolean {
   const bare = hostname.replace(/^\[|\]$/g, '').toLowerCase();


### PR DESCRIPTION
## 概要

- IPv4-mapped IPv6 アドレス（`::ffff:7f00:1` 等）による SSRF プライベートレンジ検証のバイパスをブロック
- `isPrivateIPv4()` を抽出し、IPv4 / IPv6-mapped の両方で再利用
- URL API が hex 正規化した IPv6 アドレスを dotted decimal に変換する `ipv6MappedToIPv4()` を追加
- IPv6 unspecified アドレス（`::`）をブロック

## テスト計画

- [x] IPv4-mapped プライベートレンジのブロック: loopback, 10.x, 192.168.x, 172.16-31.x, link-local, unspecified
- [x] IPv4-mapped パブリックアドレスの許可: 8.8.8.8, 172.32.x
- [x] IPv6 unspecified `[::]` のブロック
- [x] 既存テスト変更なし・全パス
- [x] `pnpm format:check && pnpm lint && pnpm check && pnpm test && pnpm test:e2e` 全パス

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)