### PR TITLE
NIP-05 キャッシュにメモリ上限を追加

### DIFF
--- a/src/lib/nostr/nip05.test.ts
+++ b/src/lib/nostr/nip05.test.ts
@@ -150,7 +150,7 @@ describe('nip05', () => {
 
     const { verifyNip05 } = await import('./nip05.js');
 
-    // Fill cache to the limit (500 entries)
+    // Insert 501 entries to exceed MAX_CACHE_SIZE (500), triggering eviction
     for (let i = 0; i < 501; i++) {
       await verifyNip05(`user@domain${i}.com`, pubkey);
     }

--- a/src/lib/nostr/nip05.ts
+++ b/src/lib/nostr/nip05.ts
@@ -96,8 +96,8 @@ export async function verifyNip05(nip05: string, pubkey: string): Promise<Nip05R
   }
 
   const result = await withConcurrencyLimit(() => fetchNip05(nip05, pubkey));
-  if (cache.size >= MAX_CACHE_SIZE) {
-    // Evict oldest entry (Map preserves insertion order)
+  if (!cache.has(cacheKey) && cache.size >= MAX_CACHE_SIZE) {
+    // Evict oldest entry (FIFO by insertion order)
     const oldest = cache.keys().next().value;
     if (oldest !== undefined) cache.delete(oldest);
   }


### PR DESCRIPTION
## 概要

NIP-05 検証キャッシュに最大 500 エントリの上限を追加。Map の挿入順序を活用した LRU 風 eviction で、長時間運用時のメモリ膨張を防止。

### 変更内容
- `src/lib/nostr/nip05.ts`: `MAX_CACHE_SIZE = 500` を追加、cache.set 前に size チェック→oldest eviction
- `src/lib/nostr/nip05.test.ts`: 501 エントリ挿入後の eviction 検証テスト追加

## テスト計画

- [x] 501 エントリ挿入後に最初のエントリが evicted されることを確認
- [x] `pnpm format:check && pnpm lint && pnpm check && pnpm test` 全パス

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)