### PR TITLE
コメント分類の derived チェーンを単一パスに最適化

### DIFF
--- a/src/lib/components/CommentList.svelte
+++ b/src/lib/components/CommentList.svelte
@@ -56,25 +56,25 @@
 
   const HIGHLIGHT_THRESHOLD_MS = 5_000;
 
-  // --- Filtered comments ---
+  // --- Filtered comments (single-pass classification) ---
   let filteredComments = $derived(
     comments
       .filter((c) => matchesFilter(c.pubkey, followFilter, auth.pubkey))
       .filter((c) => !isMuted(c.pubkey) && !isWordMuted(c.content))
   );
 
-  /** Top-level comments only (exclude replies) */
-  let topLevelComments = $derived(filteredComments.filter((c) => c.replyTo === null));
-
-  let timedComments = $derived(
-    topLevelComments
-      .filter((c) => c.positionMs !== null)
-      .sort((a, b) => a.positionMs! - b.positionMs!)
-  );
-
-  let generalComments = $derived(
-    topLevelComments.filter((c) => c.positionMs === null).sort((a, b) => b.createdAt - a.createdAt)
-  );
+  let { timedComments, generalComments } = $derived.by(() => {
+    const timed: Comment[] = [];
+    const general: Comment[] = [];
+    for (const c of filteredComments) {
+      if (c.replyTo !== null) continue;
+      if (c.positionMs !== null) timed.push(c);
+      else general.push(c);
+    }
+    timed.sort((a, b) => a.positionMs! - b.positionMs!);
+    general.sort((a, b) => b.createdAt - a.createdAt);
+    return { timedComments: timed, generalComments: general };
+  });
 
   // --- Virtual scroll auto-scroll ---
   let timedVirtualList = $state<VirtualScrollList<Comment> | undefined>();


### PR DESCRIPTION
## 概要

CommentList の3段 derived チェーン（`topLevelComments` → `timedComments` / `generalComments`）を単一の `$derived.by` に統合。中間配列の生成と重複フィルタを排除。

### Before
```
filteredComments → topLevelComments (filter) → timedComments (filter + sort)
                                              → generalComments (filter + sort)
```
3回の filter + 2回の sort = 配列全体を5回走査

### After
```
filteredComments → $derived.by (1回のループで timed/general に分類 + 各 sort)
```
1回のループ + 2回の sort = 配列全体を3回走査

### 影響
- 大量コメント (500+) 時のパフォーマンス改善
- `topLevelComments` 中間変数の削除

## テスト計画

- [x] `pnpm format:check && pnpm lint && pnpm check && pnpm test && pnpm test:e2e` 全パス

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)