### PR TITLE
subscribe() を try-catch でラップしてスピナー永久表示を防止

### DIFF
--- a/src/lib/stores/comments.svelte.ts
+++ b/src/lib/stores/comments.svelte.ts
@@ -285,6 +285,8 @@ export function createCommentsStore(contentId: ContentId, provider: ContentProvi
       await subscribeInner();
     } catch (err) {
       log.error('Failed to subscribe to comments', err);
+      for (const sub of subscriptions) sub.unsubscribe();
+      subscriptions = [];
       if (reconcileSub) {
         reconcileSub.unsubscribe();
         reconcileSub = undefined;


### PR DESCRIPTION
## 概要

`comments.svelte.ts` の `subscribe()` を try-catch でラップし、初期化フェーズの例外時に `loading = false` をセットしてスピナーが永久に表示される問題を防止。

### 問題
`subscribe()` は async だが `+page.svelte` で await されていない。以下が失敗すると loading が true のまま:
- dynamic import (`rxjs`, `rx-nostr`, etc.)
- `getRxNostr()`
- `getEventsDB()`
- `eventsDB.getByTagValue()`

### 修正
`subscribe()` → `subscribeInner()` に本体を移動し、`subscribe()` で try-catch ラップ。catch 内で `loading = false` + エラーログ。

## テスト計画

- [x] `pnpm format:check && pnpm lint && pnpm check && pnpm test && pnpm test:e2e` 全パス

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)