### PR TITLE
共有リンクのハードコード origin を除去

### DIFF
--- a/src/lib/components/ShareButton.svelte
+++ b/src/lib/components/ShareButton.svelte
@@ -79,7 +79,7 @@
 
   function buildResonoteUrl(withTime = false): string {
     const encoded = encodeContentLink(contentId, DEFAULT_RELAYS);
-    const base = `https://resonote.pages.dev/${encoded}`;
+    const base = `${window.location.origin}/${encoded}`;
     return withTime ? `${base}?t=${positionSec}` : base;
   }
 


### PR DESCRIPTION
## 概要

ShareButton の共有リンク URL を \`https://resonote.pages.dev\` から \`window.location.origin\` に置換。staging/preview/独自ドメインで正しいリンクが生成される。

extension 側の \`RESONOTE_ORIGIN\` と manifest は次回リリースで対応。

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)