### PR TITLE
Security Audit を deploy ブロッカーに昇格

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,8 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - name: Audit dependencies
-        run: pnpm audit --prod
-        continue-on-error: true
+      - name: Audit dependencies (high/critical only)
+        run: pnpm audit --prod --audit-level=high
 
   test:
     name: Unit Test + Coverage
@@ -157,7 +156,7 @@ jobs:
 
   deploy-staging:
     name: Deploy to Staging
-    needs: [lint-and-check, test, e2e, build-extension]
+    needs: [lint-and-check, audit, test, e2e, build-extension]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
@@ -193,7 +192,7 @@ jobs:
 
   deploy-production:
     name: Deploy to Production
-    needs: [lint-and-check, test, e2e, build-extension]
+    needs: [lint-and-check, audit, test, e2e, build-extension]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## 概要

- \`continue-on-error: true\` を削除
- \`--audit-level=high\` を追加（high/critical のみ失敗）
- deploy-staging / deploy-production の \`needs\` に \`audit\` を追加

## テスト計画

- [x] CI ワークフローの構文検証

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)