### PR TITLE
README に前提条件を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,15 @@ NIP-73 (External Content IDs) + NIP-22 (Comments, kind:1111) + NIP-25 (Reactions
 | NIP-73 | 外部コンテンツ ID (`i` タグ)                |
 | NIP-B0 | Web ブックマーク (kind:39701, Podcast 解決) |
 
+## 前提条件
+
+- Node.js >= 24.0.0 (Corepack 同梱)
+- pnpm (`corepack enable` で有効化、バージョンは `packageManager` フィールドで自動管理)
+
+```bash
+corepack enable
+```
+
 ## セットアップ
 
 ```bash


### PR DESCRIPTION
## 関連 Issue

closes #74

## 概要

README にランタイム前提条件（Node.js >= 24, pnpm via Corepack）を追加します。

## 変更内容

- README に「前提条件」セクションを追加
  - Node.js >= 24.0.0 (Corepack 同梱)
  - pnpm (`corepack enable` で有効化、バージョンは `packageManager` フィールドで自動管理)

### #96 との違い

PR #96 では npm scripts 内の再帰 `pnpm` 呼び出しをインライン展開で排除していましたが、検討の結果：

- `npm-run-all2` の `run-s` も内部で `pnpm run` を呼ぶため、環境継承の問題は解消されない
- インライン展開は3箇所のコマンド重複を生み、変更時の同期漏れが確実に発生する
- 現在の `pnpm run build:ext` 呼び出しは実用上問題がない（vite build + cp のみ）

よって再帰呼び出しの排除は行わず、README の前提条件追加のみ対応します。

## テスト

- [x] `pnpm format:check` 通過
- [x] `pnpm lint` 通過
- [x] `pnpm check` 通過
- [x] `pnpm test` 通過