### PR TITLE
fix: worktree ディレクトリをツール走査対象から除外 (#109)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ vite.config.ts.timestamp-*
 # Superpowers
 .superpowers/
 docs/superpowers/
-.worktrees/
 .serena/
+
+# Worktrees (git worktree add)
+.worktrees/
+.claude/worktrees/
 e2e/helpers/*.js

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,8 @@ node_modules
 build
 .svelte-kit
 .serena
+.worktrees
+.claude/worktrees
 pnpm-lock.yaml
 test-results
 playwright-report

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -409,6 +409,8 @@ export default ts.config(
       'dist-extension/',
       '.svelte-kit/',
       '.wrangler/',
+      '.worktrees/',
+      '.claude/worktrees/',
       'node_modules/',
       'test-results/',
       'playwright-report/',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,11 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   plugins: [tailwindcss(), sveltekit()],
+  server: {
+    watch: {
+      ignored: ['**/.worktrees/**', '**/.claude/worktrees/**']
+    }
+  },
   build: {
     // Large vendor chunks are lazy-loaded via dynamic import:
     // - @ikuradon/emoji-kitchen-mart-data (~10MB) — emoji dataset


### PR DESCRIPTION
## 概要

`.worktrees/` および `.claude/worktrees/` をESLint, Prettier, Vite dev server の走査対象から除外。

## 変更内容

- stale な `.worktrees/audio-provider` worktree を削除
- `.gitignore` に `.claude/worktrees/` を追加（Claude Code worktree 用）
- `.prettierignore` に `.worktrees/`, `.claude/worktrees/` を追加
- `eslint.config.js` の `ignores` に `.worktrees/`, `.claude/worktrees/` を追加
- `vite.config.ts` の `server.watch.ignored` に worktree パターンを追加

## テスト計画

- [x] `pnpm format:check` pass
- [x] `pnpm lint` pass
- [x] `pnpm check` 0 errors
- [x] `pnpm test` 898 tests pass

Closes #109