### PR TITLE
fix: プレビューデプロイ URL を wrangler-action 出力から取得

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -105,6 +105,7 @@ jobs:
           echo "name=$BRANCH" >> "$GITHUB_OUTPUT"
 
       - name: Deploy to Cloudflare Pages
+        id: deploy
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -118,9 +119,10 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
           BRANCH: ${{ steps.branch.outputs.name }}
+          DEPLOY_URL: ${{ steps.deploy.outputs.deployment-alias-url || steps.deploy.outputs.deployment-url }}
           COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          PREVIEW_URL="https://${BRANCH}.resonote-preview.pages.dev"
+          PREVIEW_URL="${DEPLOY_URL:-https://${BRANCH}.resonote-preview.pages.dev}"
           SHORT_SHA="${COMMIT_SHA::7}"
           TIMESTAMP=$(date -u '+%Y-%m-%d %H:%M UTC')
           BODY="<!-- preview-deploy -->


### PR DESCRIPTION
## 概要

プレビュー URL を手動構築（`https://${BRANCH}.resonote-preview.pages.dev`）ではなく、`cloudflare/wrangler-action` の `deployment-alias-url` 出力から取得するよう変更。

## 背景

Cloudflare Pages はブランチ名をサニタイズする場合があり、手動構築した URL と実際のデプロイ URL が一致しないことがある。

## 変更内容

- `wrangler-action` ステップに `id: deploy` を追加
- `deployment-alias-url`（ブランチエイリアス URL）を優先的に使用
- フォールバックとして `deployment-url`（デプロイメント固有 URL）を使用
- 両方取得できなかった場合のみ従来の手動構築にフォールバック