### PR TITLE
fix: プレビューコメント更新時の GraphQL node ID による 404 を修正

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -137,7 +137,7 @@ jobs:
 
           # Update existing comment or create new one
           COMMENT_ID=$(gh pr view "$PR_NUMBER" --json comments --repo "$REPO" \
-            --jq '[.comments[] | select((.author.login | startswith("github-actions")) and (.body | contains("<!-- preview-deploy -->"))) | .id] | last // ""')
+            --jq '[.comments[] | select((.author.login | startswith("github-actions")) and (.body | contains("<!-- preview-deploy -->"))) | .url | split("issuecomment-") | last] | last // ""')
 
           if [[ -n "$COMMENT_ID" ]]; then
             gh api "repos/$REPO/issues/comments/$COMMENT_ID" -X PATCH -f body="$BODY" --silent


### PR DESCRIPTION
## 概要

- `preview-deploy.yml` の既存コメント更新時、GraphQL node ID を REST API に渡して 404 になるバグを修正
- `.id`（node ID: `IC_kwDO...`）の代わりに `.url` から数値 ID を抽出するよう変更

## 原因

`gh pr view --json comments` の `.id` は GraphQL node ID を返すが、
`gh api repos/.../issues/comments/{id}` は REST API の数値 ID を期待する。
初回デプロイ（新規コメント作成）は成功するが、2回目以降のプッシュ（コメント更新パス）で必ず失敗していた。

## 変更内容

```diff
- ... | .id] | last // ""')
+ ... | .url | split("issuecomment-") | last] | last // ""')
```

## テストプラン

- [ ] PR に2回以上プッシュして、プレビューコメントが更新されることを確認
- [ ] 新規 PR を作成して、初回コメント作成が正常に動作することを確認

Closes #119