### PR TITLE
chore: 本番ドメインを resonote.cc に移行

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -284,7 +284,7 @@ Svelte 5 `$state` runes are used in owner modules, not in a central store direct
 - `getFollows().follows` は `Set<string>` → `.length` ではなく `.size` を使う
 - `static/icon.svg` がマスター SVG。PNG は `rsvg-convert -w 512 -h 512 static/icon.svg -o static/icon-512.png` で再生成 (ImageMagick はグラデーション非対応)
 - `app.html` のスプラッシュ SVG は `icon.svg` の inline 埋め込み。アイコン変更時は両方更新すること
-- OGP の `og:url` / `og:image` は `resonote.pages.dev` を使用。独自ドメイン取得時に `app.html` を更新すること
+- OGP の `og:url` / `og:image` は `resonote.cc` を使用 (prod ドメイン)。`resonote.pages.dev` は staging 扱い
 - `cachedFetchById` は fetch 中に `invalidateFetchByIdCache` が呼ばれると `invalidatedDuringFetch` Set でキャッシュ書き込みをスキップする。新規キャッシュ利用コードを書く際はこのパターンを維持すること
 - `$effect` 内で `options.getComments()` 等のリアクティブ getter を呼ぶと二重追跡される → `untrack()` でラップして依存を限定する
 - Svelte 5 `{@const}` は `{#snippet}` / `{#if}` / `{#each}` 等のブロック直下にしか置けない。`<div>` 内に置くとコンパイルエラー

--- a/src/extension/manifest.chrome.json
+++ b/src/extension/manifest.chrome.json
@@ -34,7 +34,7 @@
       "all_frames": true
     },
     {
-      "matches": ["*://resonote.pages.dev/*"],
+      "matches": ["*://resonote.cc/*"],
       "js": ["content-scripts/resonote-bridge.js"],
       "run_at": "document_start"
     }

--- a/src/extension/manifest.firefox.json
+++ b/src/extension/manifest.firefox.json
@@ -35,7 +35,7 @@
       "all_frames": true
     },
     {
-      "matches": ["*://resonote.pages.dev/*"],
+      "matches": ["*://resonote.cc/*"],
       "js": ["content-scripts/resonote-bridge.js"],
       "run_at": "document_start"
     }

--- a/src/extension/shared/constants.ts
+++ b/src/extension/shared/constants.ts
@@ -1,4 +1,4 @@
 export const SIDEPANEL_PORT_NAME = 'resonote-sidepanel';
 export const RESONOTE_EXT_ATTR = 'data-resonote-ext';
 export const RESONOTE_ACTION_ATTR = 'data-resonote-action';
-export const RESONOTE_ORIGIN = 'https://resonote.pages.dev';
+export const RESONOTE_ORIGIN = 'https://resonote.cc';

--- a/src/shared/utils/deploy-env.test.ts
+++ b/src/shared/utils/deploy-env.test.ts
@@ -36,12 +36,12 @@ describe('detectEnvFromHostname', () => {
     expect(detectEnvFromHostname('staging.resonote.pages.dev')).toBe('staging');
   });
 
-  it('maps resonote.pages.dev to production', () => {
-    expect(detectEnvFromHostname('resonote.pages.dev')).toBe('production');
+  it('maps resonote.pages.dev to staging', () => {
+    expect(detectEnvFromHostname('resonote.pages.dev')).toBe('staging');
   });
 
-  it('maps custom domain to production', () => {
-    expect(detectEnvFromHostname('resonote.app')).toBe('production');
+  it('maps resonote.cc to production', () => {
+    expect(detectEnvFromHostname('resonote.cc')).toBe('production');
   });
 
   it('maps localhost to production (DEV check is in getDeployEnv)', () => {

--- a/src/shared/utils/deploy-env.ts
+++ b/src/shared/utils/deploy-env.ts
@@ -8,7 +8,8 @@ export interface EnvBannerConfig {
 /** Detect deploy environment from hostname. Exported for testing. */
 export function detectEnvFromHostname(hostname: string): DeployEnv {
   if (hostname.endsWith('.resonote-preview.pages.dev')) return 'preview';
-  if (hostname === 'staging.resonote.pages.dev') return 'staging';
+  if (hostname === 'resonote.pages.dev' || hostname === 'staging.resonote.pages.dev')
+    return 'staging';
   return 'production';
 }
 

--- a/src/web/app.html
+++ b/src/web/app.html
@@ -15,14 +15,14 @@
     <meta name="description" content="Comment on audio and video, synced to playback time" />
     <meta property="og:title" content="Resonote" />
     <meta property="og:description" content="Comment on audio and video, synced to playback time" />
-    <meta property="og:url" content="https://resonote.pages.dev/" />
-    <meta property="og:image" content="https://resonote.pages.dev/og-image.png" />
+    <meta property="og:url" content="https://resonote.cc/" />
+    <meta property="og:image" content="https://resonote.cc/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta property="og:site_name" content="Resonote" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:image" content="https://resonote.pages.dev/og-image.png" />
+    <meta name="twitter:image" content="https://resonote.cc/og-image.png" />
     <meta name="theme-color" content="#c9a256" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />


### PR DESCRIPTION
## 概要

本番ドメインを `resonote.pages.dev` → `resonote.cc` に移行。`resonote.pages.dev` は staging 扱いに変更。

### 変更内容

- `deploy-env.ts`: `resonote.pages.dev` を staging 判定に追加（黄色バナー表示）
- `app.html`: OGP `og:url` / `og:image` を `resonote.cc` に更新
- `extension/shared/constants.ts`: `RESONOTE_ORIGIN` を `resonote.cc` に更新
- `extension/manifest.chrome.json` / `manifest.firefox.json`: content script matches を `resonote.cc` に更新
- `CLAUDE.md`: gotcha を更新
- テスト: `resonote.pages.dev` → staging、`resonote.cc` → production

## テスト計画

- [x] `pnpm format:check && pnpm lint && pnpm check && pnpm test` 全パス (1905 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)