### PR TITLE
chore: codecov/test-results-action を codecov-action@v5 に移行 (#136)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,10 +101,11 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@6ba3fdeec616fb91fd6a389b788a2366835a0fa2 # v1.2.1
+        uses: codecov/codecov-action@4481f553995cc5011b158ce191746ac1a1d0f815 # v5.5.3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: test-results/junit.xml
+          report_type: test_results
           fail_ci_if_error: false
 
       - name: Upload coverage artifact


### PR DESCRIPTION
## 概要

非推奨の `codecov/test-results-action` を `codecov/codecov-action@v5` の `report_type: test_results` に移行。

### 変更内容

- `codecov/test-results-action@v1.2.1` → `codecov/codecov-action@v5.5.3` + `report_type: test_results`
- Node.js 20 deprecation warning を解消

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)