### PR TITLE
chore: プレビューデプロイの簡略化 + GitHub Deployments 連携

### DIFF
--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -51,8 +51,8 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
-          COMMENT_ID=$(gh api "repos/$REPO/issues/${PR_NUMBER}/comments" --paginate \
-            --jq '[.[] | select((.author.login | startswith("github-actions")) and (.body | contains("<!-- preview-deploy -->"))) | .id] | last // ""')
+          COMMENT_ID=$(gh api "repos/$REPO/issues/${PR_NUMBER}/comments?per_page=100" \
+            --jq '[.[] | select((.user.login | startswith("github-actions")) and (.body | contains("<!-- preview-deploy -->"))) | .id] | last // ""')
           if [[ -n "$COMMENT_ID" ]]; then
             gh api "repos/$REPO/issues/comments/$COMMENT_ID" -X PATCH \
               -f body="<!-- preview-deploy -->

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -108,8 +108,8 @@ jobs:
           | **Updated** | ${TIMESTAMP} |"
 
           # Update existing comment or create new one
-          COMMENT_ID=$(gh api "repos/$REPO/issues/${PR_NUMBER}/comments" --paginate \
-            --jq '[.[] | select((.author.login | startswith("github-actions")) and (.body | contains("<!-- preview-deploy -->"))) | .id] | last // ""')
+          COMMENT_ID=$(gh api "repos/$REPO/issues/${PR_NUMBER}/comments?per_page=100" \
+            --jq '[.[] | select((.user.login | startswith("github-actions")) and (.body | contains("<!-- preview-deploy -->"))) | .id] | last // ""')
 
           if [[ -n "$COMMENT_ID" ]]; then
             gh api "repos/$REPO/issues/comments/$COMMENT_ID" -X PATCH -f body="$BODY" --silent


### PR DESCRIPTION
## 概要

プレビューデプロイの仕組みを簡略化し、PR 画面の Deployments セクションに表示されるようにする。

### 変更点

- **ブランチ名を決定的に**: ランダム5単語 → `pr-{番号}` に変更
- **コメントパース廃止**: ブランチ名が PR 番号から算出可能になり、正規表現による復元が不要に
- **GitHub Deployments 連携**: `environment` 設定で PR 画面に「View deployment」ボタン表示
- **クリーンアップ改善**: PR クローズ時に GitHub environment を `inactive` に設定

### Before → After

| | Before | After |
|---|---|---|
| ブランチ名 | ランダム5単語 | `pr-{番号}` |
| deploy ステップ数 | 7 | 3 |
| コメントパース | 正規表現で復元 | 不要 |
| GitHub Deployments | なし | PR 画面に表示 |

### 差分サイズ

`-55 / +28` 行（ネット -27 行）

## テストプラン

- [ ] PR 作成時にプレビューデプロイが `pr-{番号}.resonote-preview.pages.dev` に作成される
- [ ] PR 更新時に同じ URL で再デプロイされる
- [ ] PR 画面の Deployments セクションに「View deployment」が表示される
- [ ] PR クローズ時に Cloudflare デプロイ削除 + environment 非アクティブ化