### PR TITLE
fix: プレビューデプロイのアーティファクトパス修正

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -59,7 +59,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: preview-build-${{ github.event.pull_request.number }}
-          path: .svelte-kit/cloudflare/
+          path: .svelte-kit/
           retention-days: 1
 
   deploy-preview:
@@ -78,7 +78,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: preview-build-${{ github.event.pull_request.number }}
-          path: .svelte-kit/cloudflare/
+          path: .svelte-kit/
 
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3


### PR DESCRIPTION
## 概要

adapter-cloudflare の `_worker.js` が `.svelte-kit/output/server/index.js` を相対パスで参照するため、`.svelte-kit/cloudflare/` だけでは不足。`.svelte-kit/` 全体をアーティファクトに含める。

### 原因

```
_worker.js:2 → import { Server } from "./../output/server/index.js"
```

preview-deploy はビルドとデプロイが別ジョブでアーティファクト経由のため、`output/server/` が欠落して `Could not resolve` エラーが発生していた。

### 変更

- upload-artifact: `path: .svelte-kit/cloudflare/` → `path: .svelte-kit/`
- download-artifact: 同上

## テストプラン

- [ ] PR 作成時にプレビューデプロイが成功すること