### PR TITLE
fix: .svelte-kit/ の隠しディレクトリをアーティファクトに含める

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -60,6 +60,7 @@ jobs:
         with:
           name: preview-build-${{ github.event.pull_request.number }}
           path: .svelte-kit/
+          include-hidden-files: true
           retention-days: 1
 
   deploy-preview:


### PR DESCRIPTION
## 概要

\`upload-artifact@v7\` のデフォルト \`include-hidden-files: false\` により、\`.svelte-kit/\` ディレクトリ（ドットプレフィックス = 隠しディレクトリ）がアーティファクトに含まれなかった。

\`include-hidden-files: true\` を追加。

## テストプラン

- [ ] PR 作成時にプレビューデプロイが成功すること