### PR TITLE
fix: svelte-check state_referenced_locally 警告の修正

### DIFF
--- a/src/lib/components/QuoteCard.svelte
+++ b/src/lib/components/QuoteCard.svelte
@@ -10,7 +10,7 @@
 
   let { eventId, href }: Props = $props();
 
-  const vm = createQuoteViewModel(eventId);
+  const vm = $derived(createQuoteViewModel(eventId));
 
   const MAX_PREVIEW_LENGTH = 120;
   let preview = $derived.by(() => {

--- a/src/lib/components/UserAvatar.svelte
+++ b/src/lib/components/UserAvatar.svelte
@@ -13,12 +13,9 @@
   let imgError = $state(false);
 
   // Reset error state when picture URL changes (e.g. async profile load)
-  let prevPicture = $state(picture);
   $effect(() => {
-    if (picture !== prevPicture) {
-      prevPicture = picture;
-      imgError = false;
-    }
+    void picture;
+    imgError = false;
   });
 
   const sizeClass = $derived(


### PR DESCRIPTION
## 概要
- `QuoteCard.svelte`: `$derived` で eventId 変更時に VM を再生成
- `UserAvatar.svelte`: `$effect` で picture を直接追跡し `prevPicture` を削除

## テスト
- [x] `pnpm check` — 0 ERRORS 0 WARNINGS
- [x] `pnpm test` パス
- [x] `pnpm lint` パス

Closes #172