### PR TITLE
chore: Dependabot に npm パッケージ更新検知を追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,17 @@ updates:
     directory: /
     schedule:
       interval: weekly
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+      major:
+        update-types:
+          - major


### PR DESCRIPTION
## 概要
- Dependabot に `npm` エコシステムを追加し、パッケージ更新を自動検知
- minor/patch は1つの PR にグループ化、major は別グループ
- `open-pull-requests-limit: 10` で PR 数を制限
- security updates は個別 PR（Dependabot のデフォルト動作）