### PR TITLE
style: const log 宣言を import 文の後に移動

### DIFF
--- a/src/features/content-resolution/ui/resolved-content-view-model.svelte.ts
+++ b/src/features/content-resolution/ui/resolved-content-view-model.svelte.ts
@@ -16,10 +16,10 @@ import { fromBase64url } from '$shared/content/url-utils.js';
 import { createLogger } from '$shared/utils/logger.js';
 
 import { fetchContentMetadata } from '../application/fetch-content-metadata.js';
-
-const log = createLogger('resolved-content-vm');
 import { resolveAudioUrl, resolvePodcastEpisode } from '../application/resolve-content.js';
 import type { ContentMetadata } from '../domain/content-metadata.js';
+
+const log = createLogger('resolved-content-vm');
 
 type CommentVM = ReturnType<typeof createCommentViewModel>;
 

--- a/src/server/api/podbean.ts
+++ b/src/server/api/podbean.ts
@@ -6,9 +6,9 @@ import { assertSafeUrl, safeFetch, safeReadText } from '$server/lib/safe-fetch.j
 import { createLogger } from '$shared/utils/logger.js';
 
 import type { Bindings } from './bindings.js';
+import { cacheMiddleware } from './middleware/cache.js';
 
 const log = createLogger('podbean');
-import { cacheMiddleware } from './middleware/cache.js';
 
 const querySchema = z.object({
   url: z.url()


### PR DESCRIPTION
## 概要
#178 のレビューで指摘された import 順序の不統一を修正。
`const log = createLogger(...)` が import 文の間に挿入されていた2ファイルを修正。

`eslint-plugin-simple-import-sort` は既に設定済みで正常動作を確認。
import 順序違反は `pnpm lint` で検出、`pnpm lint --fix` で自動修正される。

## 変更ファイル
- `resolved-content-view-model.svelte.ts` — `const log` を全 import の後に移動
- `podbean.ts` — 同上

## テスト
- [x] `pnpm check` — 0 ERRORS 0 WARNINGS
- [x] `pnpm lint` パス
- [x] `pnpm format:check` パス