### PR TITLE
test: sendReply の relay hint 伝播テストを追加

### DIFF
--- a/src/features/comments/application/comment-actions.test.ts
+++ b/src/features/comments/application/comment-actions.test.ts
@@ -138,6 +138,20 @@ describe('sendReply', () => {
     expect(castSignedMock).toHaveBeenCalledWith(builtEvent);
   });
 
+  it('passes relayHint in parentEvent to buildComment when provided', async () => {
+    const parentWithHint = {
+      id: 'parent-event-id',
+      pubkey: 'parent-pubkey',
+      relayHint: 'wss://relay.example.com'
+    };
+    await sendReply({ content: 'reply', contentId, provider, parentEvent: parentWithHint });
+    expect(buildCommentMock).toHaveBeenCalledWith('reply', contentId, provider, {
+      positionMs: undefined,
+      emojiTags: undefined,
+      parentEvent: parentWithHint
+    });
+  });
+
   it('propagates errors from castSigned', async () => {
     castSignedMock.mockRejectedValueOnce(new Error('send failed'));
     await expect(sendReply({ content: 'reply', contentId, provider, parentEvent })).rejects.toThrow(


### PR DESCRIPTION
## 概要
クリティカルパステスト監査で発見されたギャップ。
`sendReply` に `parentEvent.relayHint` を渡した場合の `buildComment` への伝播を検証するテストが欠けていた。

## テスト
- [x] `pnpm test` パス (21 tests in comment-actions.test.ts)