### PR TITLE
fix: forward/merged/notification subscription にエラーハンドラを追加

### DIFF
--- a/src/features/comments/application/comment-subscription.test.ts
+++ b/src/features/comments/application/comment-subscription.test.ts
@@ -325,11 +325,11 @@ describe('startMergedSubscription', () => {
     startMergedSubscription(refs, filters, onPacket);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const subscribeFn = (refs.mergedStream.subscribe.mock.calls[0] as any)[0] as (
-      p: unknown
-    ) => void;
+    const observer = (refs.mergedStream.subscribe.mock.calls[0] as any)[0] as {
+      next: (p: unknown) => void;
+    };
     const fakeEvent = { id: 'e2', pubkey: 'pk2', content: '', created_at: 2, tags: [], kind: 7 };
-    subscribeFn({ event: fakeEvent });
+    observer.next({ event: fakeEvent });
     expect(onPacket).toHaveBeenCalledWith(fakeEvent, undefined);
   });
 
@@ -338,11 +338,11 @@ describe('startMergedSubscription', () => {
     startMergedSubscription(refs, filters, onPacket);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const subscribeFn = (refs.mergedStream.subscribe.mock.calls[0] as any)[0] as (
-      p: unknown
-    ) => void;
+    const observer = (refs.mergedStream.subscribe.mock.calls[0] as any)[0] as {
+      next: (p: unknown) => void;
+    };
     const fakeEvent = { id: 'e3', pubkey: 'pk3', content: '', created_at: 3, tags: [], kind: 7 };
-    subscribeFn({ event: fakeEvent, from: 'wss://relay2.test' });
+    observer.next({ event: fakeEvent, from: 'wss://relay2.test' });
     expect(onPacket).toHaveBeenCalledWith(fakeEvent, 'wss://relay2.test');
   });
 });

--- a/src/features/comments/application/comment-subscription.ts
+++ b/src/features/comments/application/comment-subscription.ts
@@ -93,9 +93,12 @@ export function startSubscription(
   const forwardSub = refs.rxNostr
     .use(forward)
     .pipe(uniq())
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    .subscribe((packet: any) => {
-      onPacket(packet.event, packet.from);
+    .subscribe({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      next: (packet: any) => onPacket(packet.event, packet.from),
+      error: (err: unknown) => {
+        log.error('Forward subscription error', err);
+      }
     });
 
   backward.emit(backwardFilters);
@@ -132,9 +135,14 @@ export function startMergedSubscription(
     refs.rxNostr.use(backward).pipe(uniq()),
     refs.rxNostr.use(forward).pipe(uniq())
   );
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const sub = merged.subscribe((rawPacket: any) => {
-    onPacket(rawPacket.event, rawPacket.from);
+  const sub = merged.subscribe({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    next: (rawPacket: any) => {
+      onPacket(rawPacket.event, rawPacket.from);
+    },
+    error: (err: unknown) => {
+      log.error('Merged subscription error', err);
+    }
   });
 
   backward.emit(filters);

--- a/src/features/notifications/ui/notifications-view-model.svelte.ts
+++ b/src/features/notifications/ui/notifications-view-model.svelte.ts
@@ -160,25 +160,30 @@ export async function subscribeNotifications(
   const notifSub = merge(
     rxNostr.use(notifBackward).pipe(uniq()),
     rxNostr.use(notifForward).pipe(uniq())
+  ).subscribe({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ).subscribe((packet: any) => {
-    const event = packet.event;
-    const type = classifyNotificationEvent(event, myPubkey, follows);
-    if (!type || type === 'follow_comment') return;
+    next: (packet: any) => {
+      const event = packet.event;
+      const type = classifyNotificationEvent(event, myPubkey, follows);
+      if (!type || type === 'follow_comment') return;
 
-    const eTag = event.tags.find((t: string[]) => t[0] === 'e' && t[1]);
-    addNotification(
-      {
-        id: event.id,
-        type,
-        pubkey: event.pubkey,
-        content: event.content,
-        createdAt: event.created_at,
-        tags: event.tags,
-        targetEventId: eTag?.[1]
-      },
-      type
-    );
+      const eTag = event.tags.find((t: string[]) => t[0] === 'e' && t[1]);
+      addNotification(
+        {
+          id: event.id,
+          type,
+          pubkey: event.pubkey,
+          content: event.content,
+          createdAt: event.created_at,
+          tags: event.tags,
+          targetEventId: eTag?.[1]
+        },
+        type
+      );
+    },
+    error: (err: unknown) => {
+      log.error('Notification subscription error', err);
+    }
   });
 
   notifBackward.emit(mentionFilter);
@@ -197,23 +202,28 @@ export async function subscribeNotifications(
   const followSub = merge(
     rxNostr.use(followBackward).pipe(uniq()),
     rxNostr.use(followForward).pipe(uniq())
+  ).subscribe({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ).subscribe((packet: any) => {
-    const event = packet.event;
-    if (event.pubkey === myPubkey) return;
-    if (!follows.has(event.pubkey)) return;
+    next: (packet: any) => {
+      const event = packet.event;
+      if (event.pubkey === myPubkey) return;
+      if (!follows.has(event.pubkey)) return;
 
-    addNotification(
-      {
-        id: event.id,
-        type: 'follow_comment',
-        pubkey: event.pubkey,
-        content: event.content,
-        createdAt: event.created_at,
-        tags: event.tags
-      },
-      'follow_comment'
-    );
+      addNotification(
+        {
+          id: event.id,
+          type: 'follow_comment',
+          pubkey: event.pubkey,
+          content: event.content,
+          createdAt: event.created_at,
+          tags: event.tags
+        },
+        'follow_comment'
+      );
+    },
+    error: (err: unknown) => {
+      log.error('Follow comments subscription error', err);
+    }
   });
 
   for (let i = 0; i < followArray.length; i += BATCH_SIZE) {

--- a/src/features/notifications/ui/notifications-view-model.test.ts
+++ b/src/features/notifications/ui/notifications-view-model.test.ts
@@ -68,8 +68,8 @@ vi.mock('../domain/notification-classifier.js', () => ({
 // Mock rxjs and rx-nostr for dynamic imports
 vi.mock('rxjs', () => ({
   merge: vi.fn(() => ({
-    subscribe: vi.fn((cb: (packet: unknown) => void) => {
-      subscriberCallbacks.push(cb);
+    subscribe: vi.fn((observer: { next: (packet: unknown) => void }) => {
+      subscriberCallbacks.push(observer.next);
       return { unsubscribe: unsubscribeMock };
     })
   }))


### PR DESCRIPTION
## 概要
backward subscription には error コールバックがあるが、forward/merged/notification subscription にはなかった。
bare function → `{ next, error }` オブジェクト形式に統一。

## 変更ファイル
- `comment-subscription.ts` — forward/merged subscription に error handler 追加
- `notifications-view-model.svelte.ts` — notification/follow subscription に error handler 追加
- `comment-subscription.test.ts` — merged subscription テスト更新
- `notifications-view-model.test.ts` — subscribe mock 更新

## テスト
- [x] `pnpm test` パス (2573 テスト)
- [x] `pnpm check` パス
- [x] `pnpm lint` パス

Closes #194