### PR TITLE
fix: リリース前セキュリティ・NIP準拠・テスト改善バッチ

### DIFF
--- a/src/features/content-resolution/application/fetch-content-metadata.ts
+++ b/src/features/content-resolution/application/fetch-content-metadata.ts
@@ -1,5 +1,6 @@
 import { apiClient } from '$shared/api/client.js';
 import type { ContentId } from '$shared/content/types.js';
+import { sanitizeUrl } from '$shared/utils/url.js';
 
 import type { ContentMetadata } from '../domain/content-metadata.js';
 
@@ -38,7 +39,7 @@ export async function fetchContentMetadata(contentId: ContentId): Promise<Conten
     return {
       title: data.title,
       subtitle: data.subtitle,
-      thumbnailUrl: data.thumbnailUrl,
+      thumbnailUrl: sanitizeUrl(data.thumbnailUrl ?? undefined) ?? null,
       description: data.description ?? null
     };
   } catch {

--- a/src/features/profiles/ui/profile-page-view-model.test.ts
+++ b/src/features/profiles/ui/profile-page-view-model.test.ts
@@ -437,4 +437,46 @@ describe('createProfilePageViewModel', () => {
       expect(vm.confirmDialog.cancelLabel).toBe('confirm.cancel');
     });
   });
+
+  // Note: Lines inside $effect blocks (104-145, 147-150, 152-191) cannot be covered
+  // in vitest because Svelte 5 $effect does not execute outside component context.
+  // These paths are covered by E2E tests instead.
+
+  describe('requestMuteUser edge cases', () => {
+    it('uses current muteList size for before/after counts', () => {
+      muteListState.mutedPubkeys = new Set(['a', 'b']);
+      decodeNip19Mock.mockReturnValue(null);
+      const vm = createProfilePageViewModel(() => 'x');
+
+      vm.requestMuteUser('new-target');
+
+      expect(tMock).toHaveBeenCalledWith('confirm.mute.detail', { before: 2, after: 3 });
+      expect(vm.confirmDialog.variant).toBe('danger');
+    });
+  });
+
+  describe('multiple mute requests', () => {
+    it('replaces previous confirm action when new mute requested', () => {
+      decodeNip19Mock.mockReturnValue(null);
+      const vm = createProfilePageViewModel(() => 'x');
+
+      vm.requestMuteUser('first');
+      vm.requestMuteUser('second');
+
+      // Only second action should execute
+      expect(vm.confirmDialog.open).toBe(true);
+    });
+
+    it('executes the last requested mute action on confirm', async () => {
+      decodeNip19Mock.mockReturnValue(null);
+      const vm = createProfilePageViewModel(() => 'x');
+
+      vm.requestMuteUser('first');
+      vm.requestMuteUser('second');
+      await vm.confirmCurrentAction();
+
+      expect(muteUserMock).toHaveBeenCalledWith('second');
+      expect(muteUserMock).not.toHaveBeenCalledWith('first');
+    });
+  });
 });

--- a/src/server/lib/audio-metadata.test.ts
+++ b/src/server/lib/audio-metadata.test.ts
@@ -856,6 +856,21 @@ describe('audio-metadata', () => {
       const result = await fetchAudioMetadata('https://example.com/test.flac');
       expect(result.image).toBeUndefined();
     });
+
+    it('should fall back to image/jpeg for disallowed MIME in FLAC PICTURE', async () => {
+      const comments = buildVorbisCommentBlock(['TITLE=Bad MIME']);
+      const commentBlock = buildFlacMetadataBlock(4, comments, false);
+
+      const fakeImage = new Array(20).fill(0xab);
+      const pictureData = buildFlacPictureData('image/svg+xml', '', fakeImage);
+      const pictureBlock = buildFlacMetadataBlock(6, pictureData, true);
+
+      const data = new Uint8Array([...strToBytes('fLaC'), ...commentBlock, ...pictureBlock]);
+      vi.stubGlobal('fetch', mockFetch(data));
+
+      const result = await fetchAudioMetadata('https://example.com/test.flac');
+      expect(result.image).toMatch(/^data:image\/jpeg;base64,/);
+    });
   });
 
   describe('fetchAudioMetadata', () => {

--- a/src/server/lib/audio-metadata.test.ts
+++ b/src/server/lib/audio-metadata.test.ts
@@ -446,7 +446,7 @@ describe('audio-metadata', () => {
         vi.stubGlobal('fetch', mockFetch(data));
 
         const result = await fetchAudioMetadata('https://example.com/test.mp3');
-        expect(result.image).toMatch(new RegExp(`^data:${allowedMime.replace('/', '/')};base64,`));
+        expect(result.image).toMatch(new RegExp(`^data:${allowedMime};base64,`));
       }
     });
 

--- a/src/server/lib/audio-metadata.test.ts
+++ b/src/server/lib/audio-metadata.test.ts
@@ -436,6 +436,41 @@ describe('audio-metadata', () => {
       const result = await fetchAudioMetadata('https://example.com/test.mp3');
       expect(result.image).toBeUndefined();
     });
+
+    it('should pass through allowed MIME types (image/png, image/gif, image/webp)', async () => {
+      for (const allowedMime of ['image/png', 'image/gif', 'image/webp']) {
+        const fakeImage = new Array(20).fill(0xab);
+        const apicPayload = buildApicFrame(allowedMime, fakeImage, 0);
+        const frames = buildId3v2Frame('APIC', apicPayload);
+        const data = buildId3v2Tag(frames);
+        vi.stubGlobal('fetch', mockFetch(data));
+
+        const result = await fetchAudioMetadata('https://example.com/test.mp3');
+        expect(result.image).toMatch(new RegExp(`^data:${allowedMime.replace('/', '/')};base64,`));
+      }
+    });
+
+    it('should fall back to image/jpeg for disallowed MIME types (image/svg+xml)', async () => {
+      const fakeImage = new Array(20).fill(0xab);
+      const apicPayload = buildApicFrame('image/svg+xml', fakeImage, 0);
+      const frames = buildId3v2Frame('APIC', apicPayload);
+      const data = buildId3v2Tag(frames);
+      vi.stubGlobal('fetch', mockFetch(data));
+
+      const result = await fetchAudioMetadata('https://example.com/test.mp3');
+      expect(result.image).toMatch(/^data:image\/jpeg;base64,/);
+    });
+
+    it('should fall back to image/jpeg for disallowed MIME types (text/html)', async () => {
+      const fakeImage = new Array(20).fill(0xab);
+      const apicPayload = buildApicFrame('text/html', fakeImage, 0);
+      const frames = buildId3v2Frame('APIC', apicPayload);
+      const data = buildId3v2Tag(frames);
+      vi.stubGlobal('fetch', mockFetch(data));
+
+      const result = await fetchAudioMetadata('https://example.com/test.mp3');
+      expect(result.image).toMatch(/^data:image\/jpeg;base64,/);
+    });
   });
 
   describe('Vorbis comment parsing (OGG)', () => {

--- a/src/server/lib/audio-metadata.ts
+++ b/src/server/lib/audio-metadata.ts
@@ -15,6 +15,7 @@ export interface AudioMetadata {
 }
 
 const RANGE_SIZE = 256 * 1024; // 256KB — enough for most ID3v2 + cover art
+const ALLOWED_IMAGE_MIMES = new Set(['image/jpeg', 'image/png', 'image/gif', 'image/webp']);
 
 export async function fetchAudioMetadata(
   url: string,
@@ -204,7 +205,7 @@ function decodeApic(frame: Uint8Array): string | undefined {
   // Limit cover art to 100KB to keep response reasonable
   if (imageData.length > 100 * 1024) return undefined;
 
-  const mimeType = mime || 'image/jpeg';
+  const mimeType = mime && ALLOWED_IMAGE_MIMES.has(mime) ? mime : 'image/jpeg';
   const base64 = uint8ToBase64(imageData);
   return `data:${mimeType};base64,${base64}`;
 }

--- a/src/server/lib/audio-metadata.ts
+++ b/src/server/lib/audio-metadata.ts
@@ -364,7 +364,8 @@ function parseFlacPicture(data: Uint8Array): string | undefined {
   if (offset + picLen > data.length || picLen > 100 * 1024) return undefined;
 
   const imageData = data.subarray(offset, offset + picLen);
-  return `data:${mime};base64,${uint8ToBase64(imageData)}`;
+  const mimeType = mime && ALLOWED_IMAGE_MIMES.has(mime) ? mime : 'image/jpeg';
+  return `data:${mimeType};base64,${uint8ToBase64(imageData)}`;
 }
 
 // --- Helpers ---

--- a/src/shared/nostr/events.test.ts
+++ b/src/shared/nostr/events.test.ts
@@ -311,12 +311,12 @@ describe('buildReaction', () => {
   const targetEventId = 'event123abc';
   const targetPubkey = 'pubkey456def';
 
-  it('should build a kind:7 event with default + reaction', () => {
+  it('should build a kind:7 event with default + reaction and pubkey in e-tag', () => {
     const event = buildReaction(targetEventId, targetPubkey, trackId, provider);
     expect(event.kind).toBe(7);
     expect(event.content).toBe('+');
     expect(event.tags).toEqual([
-      ['e', 'event123abc'],
+      ['e', 'event123abc', '', 'pubkey456def'],
       ['p', 'pubkey456def'],
       ['k', '1111'],
       ['I', 'spotify:track:abc123', 'https://open.spotify.com/track/abc123']
@@ -333,9 +333,9 @@ describe('buildReaction', () => {
     expect(event.content).toBe('-');
   });
 
-  it('should include correct e, p, and k tags', () => {
+  it('should include correct e (4 elements), p, and k tags', () => {
     const event = buildReaction(targetEventId, targetPubkey, trackId, provider);
-    expect(event.tags![0]).toEqual(['e', targetEventId]);
+    expect(event.tags![0]).toEqual(['e', targetEventId, '', targetPubkey]);
     expect(event.tags![1]).toEqual(['p', targetPubkey]);
     expect(event.tags![2]).toEqual(['k', '1111']);
   });
@@ -381,7 +381,7 @@ describe('buildReaction', () => {
     expect(emojiTag).toBeUndefined();
   });
 
-  it('should include relay hint in e-tag and p-tag when provided', () => {
+  it('should include relay hint and pubkey hint in e-tag when provided', () => {
     const event = buildReaction(
       'evt123',
       'pk456',
@@ -391,13 +391,13 @@ describe('buildReaction', () => {
       undefined,
       'wss://relay.example.com'
     );
-    expect(event.tags).toContainEqual(['e', 'evt123', 'wss://relay.example.com']);
+    expect(event.tags).toContainEqual(['e', 'evt123', 'wss://relay.example.com', 'pk456']);
     expect(event.tags).toContainEqual(['p', 'pk456', 'wss://relay.example.com']);
   });
 
-  it('should omit relay hint from e-tag and p-tag when not provided', () => {
+  it('should use empty relay hint placeholder in e-tag when relayHint not provided', () => {
     const event = buildReaction('evt123', 'pk456', trackId, provider);
-    expect(event.tags).toContainEqual(['e', 'evt123']);
+    expect(event.tags).toContainEqual(['e', 'evt123', '', 'pk456']);
     expect(event.tags).toContainEqual(['p', 'pk456']);
   });
 });

--- a/src/shared/nostr/events.ts
+++ b/src/shared/nostr/events.ts
@@ -188,7 +188,9 @@ export function buildReaction(
 ): EventParameters {
   const [idValue, idHint] = provider.toNostrTag(contentId);
   const tags: string[][] = [
-    relayHint ? ['e', targetEventId, relayHint] : ['e', targetEventId],
+    relayHint
+      ? ['e', targetEventId, relayHint, targetPubkey]
+      : ['e', targetEventId, '', targetPubkey],
     relayHint ? ['p', targetPubkey, relayHint] : ['p', targetPubkey],
     ['k', COMMENT_KIND_STR],
     ['I', idValue, idHint]

--- a/src/shared/nostr/nip05.test.ts
+++ b/src/shared/nostr/nip05.test.ts
@@ -167,6 +167,61 @@ describe('nip05', () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
+  it('should return valid: false for localhost domain without calling fetch', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    const { verifyNip05 } = await import('./nip05.js');
+    const result = await verifyNip05('alice@localhost', 'deadbeef'.repeat(8));
+
+    expect(result.valid).toBe(false);
+    expect(result.nip05).toBe('alice@localhost');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('should return valid: false for 127.0.0.1 domain without calling fetch', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    const { verifyNip05 } = await import('./nip05.js');
+    const result = await verifyNip05('alice@127.0.0.1', 'deadbeef'.repeat(8));
+
+    expect(result.valid).toBe(false);
+    expect(result.nip05).toBe('alice@127.0.0.1');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('should return valid: false for 192.168.1.1 domain without calling fetch', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    const { verifyNip05 } = await import('./nip05.js');
+    const result = await verifyNip05('alice@192.168.1.1', 'deadbeef'.repeat(8));
+
+    expect(result.valid).toBe(false);
+    expect(result.nip05).toBe('alice@192.168.1.1');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('should return valid: false for [::1] IPv6 domain without calling fetch', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    const { verifyNip05 } = await import('./nip05.js');
+    const result = await verifyNip05('alice@[::1]', 'deadbeef'.repeat(8));
+
+    expect(result.valid).toBe(false);
+    expect(result.nip05).toBe('alice@[::1]');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('should return valid: false for localhost:3000 domain without calling fetch', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    const { verifyNip05 } = await import('./nip05.js');
+    const result = await verifyNip05('alice@localhost:3000', 'deadbeef'.repeat(8));
+
+    expect(result.valid).toBe(false);
+    expect(result.nip05).toBe('alice@localhost:3000');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
   it('clearNip05Cache should allow re-fetching after clearing', async () => {
     const pubkey = 'deadbeef'.repeat(8);
     const fetchSpy = vi

--- a/src/shared/nostr/nip05.ts
+++ b/src/shared/nostr/nip05.ts
@@ -38,6 +38,13 @@ async function withConcurrencyLimit<T>(fn: () => Promise<T>): Promise<T> {
   }
 }
 
+function isUnsafeDomain(domain: string): boolean {
+  if (!domain || domain === 'localhost') return true;
+  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(domain)) return true;
+  if (domain.startsWith('[') || domain.includes(':')) return true;
+  return false;
+}
+
 async function fetchNip05(nip05: string, pubkey: string): Promise<Nip05Result> {
   const atIndex = nip05.indexOf('@');
   if (atIndex === -1 || atIndex === 0 || atIndex === nip05.length - 1) {
@@ -47,6 +54,11 @@ async function fetchNip05(nip05: string, pubkey: string): Promise<Nip05Result> {
 
   const local = nip05.slice(0, atIndex);
   const domain = nip05.slice(atIndex + 1);
+
+  if (isUnsafeDomain(domain)) {
+    log.warn('NIP-05 unsafe domain rejected', { domain, nip05 });
+    return { valid: false, nip05, checkedAt: Date.now() };
+  }
   const url = `https://${domain}/.well-known/nostr.json?name=${encodeURIComponent(local)}`;
 
   const controller = new AbortController();

--- a/src/shared/nostr/nip05.ts
+++ b/src/shared/nostr/nip05.ts
@@ -39,7 +39,7 @@ async function withConcurrencyLimit<T>(fn: () => Promise<T>): Promise<T> {
 }
 
 function isUnsafeDomain(domain: string): boolean {
-  if (!domain || domain === 'localhost') return true;
+  if (!domain || domain.toLowerCase() === 'localhost') return true;
   if (/^\d{1,3}(\.\d{1,3}){3}$/.test(domain)) return true;
   if (domain.startsWith('[') || domain.includes(':')) return true;
   return false;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -55,6 +55,7 @@ export default defineConfig({
         'src/shared/browser/locale.ts',
         'src/shared/browser/media-query.ts',
         'src/shared/browser/mute.ts',
+        'src/shared/browser/notifications.ts',
         'src/shared/browser/player.ts',
         'src/shared/browser/profile.ts',
         'src/shared/browser/relays.ts',


### PR DESCRIPTION
## 概要

リリース前総合レビューで検出された7件の修正をバッチ適用。

- **セキュリティ修正 3件**: MIME ホワイトリスト、thumbnailUrl サニタイズ、NIP-05 ドメイン検証
- **テスト改善 2件**: カバレッジ除外設定、profile VM テスト追加
- **NIP-25 準拠 1件**: reaction e-tag に pubkey hint 追加
- **バンドル分析 1件**: #206 に分析結果をコメント

## 変更内容

### セキュリティ

- **#199** audio metadata の APIC MIME タイプを `image/jpeg|png|gif|webp` のホワイトリストで検証。不許可 MIME は `image/jpeg` にフォールバック
- **#200** oEmbed API の `thumbnailUrl` に `sanitizeUrl()` を適用し、`javascript:` / `data:` スキームを拒否
- **#201** NIP-05 検証で `localhost`、プライベート IP、IPv6 ドメインを拒否

### NIP 準拠

- **#204** `buildReaction` の `e` タグを NIP-25 推奨の4要素形式 `['e', id, relayHint, pubkey]` に変更

### テスト

- **#202** `notifications.ts` (re-export facade) をカバレッジ除外に追加
- **#203** `profile-page-view-model` のテスト追加 + `$effect` 制約のドキュメントコメント

### バンドル分析

- **#206** 巨大チャンク (10MB) の原因が `@ikuradon/emoji-kitchen-mart` (9.5MB JSON) であることを特定。issue にコメント済み

## テスト計画

- [x] `pnpm format:check` — pass
- [x] `pnpm lint` — pass
- [x] `pnpm check` — 0 errors
- [x] `pnpm test` — 2584 tests passed
- [ ] `pnpm test:e2e` — CI で実行

Closes #199, Closes #200, Closes #201, Closes #202, Closes #203, Closes #204