### PR TITLE
fix: リリース前コードレビュー指摘修正 (H-3, M-1~M-7)

### DIFF
--- a/src/features/content-resolution/infra/soundcloud-api-client.test.ts
+++ b/src/features/content-resolution/infra/soundcloud-api-client.test.ts
@@ -40,4 +40,16 @@ describe('resolveSoundCloudEmbed', () => {
       'No iframe src in oEmbed response'
     );
   });
+
+  it('should reject a non-SoundCloud URL', async () => {
+    await expect(resolveSoundCloudEmbed('https://evil.com/track')).rejects.toThrow(
+      'Invalid SoundCloud URL'
+    );
+  });
+
+  it('should reject a non-https URL', async () => {
+    await expect(resolveSoundCloudEmbed('http://soundcloud.com/artist/track')).rejects.toThrow(
+      'Invalid SoundCloud URL'
+    );
+  });
 });

--- a/src/features/content-resolution/infra/soundcloud-api-client.ts
+++ b/src/features/content-resolution/infra/soundcloud-api-client.ts
@@ -8,6 +8,10 @@ export interface SoundCloudOEmbedResult {
 }
 
 export async function resolveSoundCloudEmbed(trackUrl: string): Promise<string> {
+  if (!trackUrl.startsWith('https://soundcloud.com/')) {
+    throw new Error('Invalid SoundCloud URL');
+  }
+
   const res = await fetch(
     `https://soundcloud.com/oembed?format=json&url=${encodeURIComponent(trackUrl)}`
   );

--- a/src/features/content-resolution/ui/PodcastEpisodeList.svelte
+++ b/src/features/content-resolution/ui/PodcastEpisodeList.svelte
@@ -1,14 +1,13 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
-  // eslint-disable-next-line no-restricted-imports -- orchestrates feed resolution; full refactor deferred
-  import { resolvePodcastFeed } from '$features/content-resolution/application/resolve-feed.js';
+  import WaveformLoader from '$lib/components/WaveformLoader.svelte';
   import { buildEpisodeContentId } from '$shared/content/resolution.js';
   import type { ContentId } from '$shared/content/types.js';
   import { fromBase64url } from '$shared/content/url-utils.js';
   import { t } from '$shared/i18n/t.js';
   import { formatCompactDuration, formatDateOnly } from '$shared/utils/format.js';
 
-  import WaveformLoader from './WaveformLoader.svelte';
+  import { resolvePodcastFeed } from '../application/resolve-feed.js';
 
   interface Props {
     contentId: ContentId;

--- a/src/features/content-resolution/ui/SoundCloudEmbed.svelte
+++ b/src/features/content-resolution/ui/SoundCloudEmbed.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-  // eslint-disable-next-line no-restricted-imports -- orchestrates embed URL resolution; full refactor deferred
-  import { resolveSoundCloudEmbed } from '$features/content-resolution/application/resolve-soundcloud-embed.js';
+  import EmbedLoading from '$lib/components/EmbedLoading.svelte';
   import { createAsyncReadyTimeout } from '$shared/browser/async-ready-timeout.js';
   import { onTogglePlayback } from '$shared/browser/playback-bridge.js';
   import { setContent, updatePlayback } from '$shared/browser/player.js';
@@ -11,7 +10,7 @@
   import { t } from '$shared/i18n/t.js';
   import { createLogger } from '$shared/utils/logger.js';
 
-  import EmbedLoading from './EmbedLoading.svelte';
+  import { resolveSoundCloudEmbed } from '../application/resolve-soundcloud-embed.js';
 
   const log = createLogger('SoundCloudEmbed');
 

--- a/src/features/content-resolution/ui/YouTubeFeedList.svelte
+++ b/src/features/content-resolution/ui/YouTubeFeedList.svelte
@@ -1,15 +1,14 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
-  // eslint-disable-next-line no-restricted-imports -- orchestrates feed resolution; full refactor deferred
-  import {
-    resolveYouTubeFeed,
-    type YouTubeFeedVideo
-  } from '$features/content-resolution/application/resolve-youtube-feed.js';
+  import WaveformLoader from '$lib/components/WaveformLoader.svelte';
   import type { ContentId } from '$shared/content/types.js';
   import { t } from '$shared/i18n/t.js';
   import { formatDateOnly } from '$shared/utils/format.js';
 
-  import WaveformLoader from './WaveformLoader.svelte';
+  import {
+    resolveYouTubeFeed,
+    type YouTubeFeedVideo
+  } from '../application/resolve-youtube-feed.js';
 
   interface Props {
     contentId: ContentId;

--- a/src/features/content-resolution/ui/embed-component-loader.ts
+++ b/src/features/content-resolution/ui/embed-component-loader.ts
@@ -10,7 +10,7 @@ export type EmbedComponentLoader = () => Promise<EmbedComponentModule>;
 const EMBED_COMPONENT_LOADERS: Record<string, EmbedComponentLoader> = {
   spotify: () => import('$lib/components/SpotifyEmbed.svelte'),
   youtube: () => import('$lib/components/YouTubeEmbed.svelte'),
-  soundcloud: () => import('$lib/components/SoundCloudEmbed.svelte'),
+  soundcloud: () => import('./SoundCloudEmbed.svelte'),
   vimeo: () => import('$lib/components/VimeoEmbed.svelte'),
   mixcloud: () => import('$lib/components/MixcloudEmbed.svelte'),
   spreaker: () => import('$lib/components/SpreakerEmbed.svelte'),

--- a/src/features/content-resolution/ui/resolved-content-view-model.svelte.ts
+++ b/src/features/content-resolution/ui/resolved-content-view-model.svelte.ts
@@ -7,8 +7,8 @@
 import { untrack } from 'svelte';
 
 import { replaceState } from '$app/navigation';
-import { createCommentViewModel } from '$shared/browser/comments.js';
 import { addBookmark, isBookmarked, removeBookmark } from '$shared/browser/bookmarks.js';
+import { createCommentViewModel } from '$shared/browser/comments.js';
 import { requestSeek, resetPlayer } from '$shared/browser/player.js';
 import type { ContentId, ContentProvider } from '$shared/content/types.js';
 import { fromBase64url } from '$shared/content/url-utils.js';

--- a/src/features/content-resolution/ui/resolved-content-view-model.svelte.ts
+++ b/src/features/content-resolution/ui/resolved-content-view-model.svelte.ts
@@ -7,8 +7,7 @@
 import { untrack } from 'svelte';
 
 import { replaceState } from '$app/navigation';
-// eslint-disable-next-line no-restricted-imports -- TODO: extract comment VM creation to a shared interface
-import { createCommentViewModel } from '$features/comments/ui/comment-view-model.svelte.js';
+import { createCommentViewModel } from '$shared/browser/comments.js';
 import { addBookmark, isBookmarked, removeBookmark } from '$shared/browser/bookmarks.js';
 import { requestSeek, resetPlayer } from '$shared/browser/player.js';
 import type { ContentId, ContentProvider } from '$shared/content/types.js';

--- a/src/lib/components/CommentList.svelte
+++ b/src/lib/components/CommentList.svelte
@@ -182,7 +182,7 @@
     // Wait for tab content to render, then scroll to the comment
     void tick().then(() => {
       requestAnimationFrame(() => {
-        const el = document.querySelector(`[data-comment-id="${highlightCommentId}"]`);
+        const el = document.querySelector(`[data-comment-id="${CSS.escape(highlightCommentId)}"]`);
         el?.scrollIntoView({ behavior: 'smooth', block: 'center' });
 
         // Brief highlight effect

--- a/src/server/api/middleware/error-handler.test.ts
+++ b/src/server/api/middleware/error-handler.test.ts
@@ -11,19 +11,55 @@ describe('errorHandler', () => {
     return app;
   }
 
-  it('should return HTTPException status and message', async () => {
+  it('should return safe message for 400 HTTPException', async () => {
     const app = createApp();
     app.get('/test', () => {
-      throw new HTTPException(400, { message: 'bad request' });
+      throw new HTTPException(400, { message: 'internal detail leak' });
     });
 
     const res = await app.request('/test');
     expect(res.status).toBe(400);
     const data = await res.json();
-    expect(data).toEqual({ error: 'bad request' });
+    expect(data).toEqual({ error: 'Bad Request' });
   });
 
-  it('should return 500 for unknown errors', async () => {
+  it('should return safe message for 404 HTTPException', async () => {
+    const app = createApp();
+    app.get('/test', () => {
+      throw new HTTPException(404, { message: '/secret/internal/path' });
+    });
+
+    const res = await app.request('/test');
+    expect(res.status).toBe(404);
+    const data = await res.json();
+    expect(data).toEqual({ error: 'Not Found' });
+  });
+
+  it('should return safe message for 429 HTTPException', async () => {
+    const app = createApp();
+    app.get('/test', () => {
+      throw new HTTPException(429, { message: 'rate limited' });
+    });
+
+    const res = await app.request('/test');
+    expect(res.status).toBe(429);
+    const data = await res.json();
+    expect(data).toEqual({ error: 'Too Many Requests' });
+  });
+
+  it('should fallback to Internal Server Error for unknown status', async () => {
+    const app = createApp();
+    app.get('/test', () => {
+      throw new HTTPException(418, { message: 'teapot' });
+    });
+
+    const res = await app.request('/test');
+    expect(res.status).toBe(418);
+    const data = await res.json();
+    expect(data).toEqual({ error: 'Internal Server Error' });
+  });
+
+  it('should return 500 for non-HTTPException errors', async () => {
     const app = createApp();
     app.get('/test', () => {
       throw new Error('unexpected');

--- a/src/server/api/middleware/error-handler.ts
+++ b/src/server/api/middleware/error-handler.ts
@@ -6,7 +6,13 @@ const SAFE_MESSAGES: Partial<Record<number, string>> = {
   401: 'Unauthorized',
   403: 'Forbidden',
   404: 'Not Found',
-  429: 'Too Many Requests'
+  405: 'Method Not Allowed',
+  409: 'Conflict',
+  413: 'Payload Too Large',
+  422: 'Unprocessable Entity',
+  429: 'Too Many Requests',
+  502: 'Bad Gateway',
+  503: 'Service Unavailable'
 };
 
 export function errorHandler(err: Error, c: Context): Response {

--- a/src/server/api/middleware/error-handler.ts
+++ b/src/server/api/middleware/error-handler.ts
@@ -1,9 +1,17 @@
 import type { Context } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 
+const SAFE_MESSAGES: Record<number, string> = {
+  400: 'Bad Request',
+  401: 'Unauthorized',
+  403: 'Forbidden',
+  404: 'Not Found',
+  429: 'Too Many Requests'
+};
+
 export function errorHandler(err: Error, c: Context): Response {
   if (err instanceof HTTPException) {
-    return c.json({ error: err.message }, err.status);
+    return c.json({ error: SAFE_MESSAGES[err.status] ?? 'Internal Server Error' }, err.status);
   }
   console.error('Unhandled API error:', err);
   return c.json({ error: 'Internal Server Error' }, 500);

--- a/src/server/api/middleware/error-handler.ts
+++ b/src/server/api/middleware/error-handler.ts
@@ -1,7 +1,7 @@
 import type { Context } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 
-const SAFE_MESSAGES: Record<number, string> = {
+const SAFE_MESSAGES: Partial<Record<number, string>> = {
   400: 'Bad Request',
   401: 'Unauthorized',
   403: 'Forbidden',

--- a/src/shared/browser/comments.ts
+++ b/src/shared/browser/comments.ts
@@ -1,3 +1,3 @@
 // Re-export facade — provides comment VM creation without cross-feature direct import.
-// eslint-disable-next-line no-restricted-imports -- facade: shared/browser re-exports feature internals
+
 export { createCommentViewModel } from '$features/comments/ui/comment-view-model.svelte.js';

--- a/src/shared/browser/comments.ts
+++ b/src/shared/browser/comments.ts
@@ -1,0 +1,3 @@
+// Re-export facade — provides comment VM creation without cross-feature direct import.
+// eslint-disable-next-line no-restricted-imports -- facade: shared/browser re-exports feature internals
+export { createCommentViewModel } from '$features/comments/ui/comment-view-model.svelte.js';

--- a/src/shared/content/audio.test.ts
+++ b/src/shared/content/audio.test.ts
@@ -111,6 +111,10 @@ describe('AudioProvider', () => {
       const contentId = { platform: 'audio', type: 'track', id: 'dummy' };
       expect(provider.contentKind(contentId)).toBe('audio:track');
     });
+
+    it('should fallback to "audio:track" when called without contentId', () => {
+      expect(provider.contentKind()).toBe('audio:track');
+    });
   });
 
   describe('embedUrl', () => {

--- a/src/shared/content/audio.test.ts
+++ b/src/shared/content/audio.test.ts
@@ -98,17 +98,18 @@ describe('AudioProvider', () => {
   });
 
   describe('toNostrTag', () => {
-    it('should return [audio:<url>, <url>] format', () => {
+    it('should return [audio:track:<url>, <url>] format', () => {
       const url = 'https://example.com/episode.mp3';
       const contentId = { platform: 'audio', type: 'track', id: toBase64url(url) };
       const tag = provider.toNostrTag(contentId);
-      expect(tag).toEqual([`audio:${url}`, url]);
+      expect(tag).toEqual([`audio:track:${url}`, url]);
     });
   });
 
   describe('contentKind', () => {
-    it('should return "audio:track"', () => {
-      expect(provider.contentKind()).toBe('audio:track');
+    it('should return "audio:track" using contentId.type', () => {
+      const contentId = { platform: 'audio', type: 'track', id: 'dummy' };
+      expect(provider.contentKind(contentId)).toBe('audio:track');
     });
   });
 

--- a/src/shared/content/audio.ts
+++ b/src/shared/content/audio.ts
@@ -27,11 +27,11 @@ export class AudioProvider implements ContentProvider {
   toNostrTag(contentId: ContentId): [string, string] {
     const decodedUrl = fromBase64url(contentId.id);
     if (decodedUrl === null) throw new Error(`Failed to decode audio URL from id: ${contentId.id}`);
-    return [`audio:${decodedUrl}`, decodedUrl];
+    return [`audio:${contentId.type}:${decodedUrl}`, decodedUrl];
   }
 
-  contentKind(): string {
-    return 'audio:track';
+  contentKind(contentId?: ContentId): string {
+    return `audio:${contentId?.type ?? 'track'}`;
   }
 
   embedUrl(contentId: ContentId): string {

--- a/src/shared/content/providers.test.ts
+++ b/src/shared/content/providers.test.ts
@@ -470,8 +470,7 @@ describe('PodbeanProvider', () => {
 
 // ---------------------------------------------------------------------------
 // AudioProvider
-// Note: toNostrTag value format is `audio:<rawUrl>` (not `audio:track:<id>`),
-// so the prefix consistency check uses the "audio" platform prefix only.
+// toNostrTag value format: `audio:track:<rawUrl>` (NIP-73 platform:type:id)
 // ---------------------------------------------------------------------------
 describe('AudioProvider', () => {
   const provider = new AudioProvider();
@@ -494,20 +493,21 @@ describe('AudioProvider', () => {
     expect(provider.parseUrl('')).toBeNull();
   });
 
-  it('toNostrTag: returns [audio:<url>, <url>]', () => {
+  it('toNostrTag: returns [audio:track:<url>, <url>]', () => {
     const contentId = { platform: 'audio', type: 'track', id: audioId };
-    expect(provider.toNostrTag(contentId)).toEqual([`audio:${audioUrl}`, audioUrl]);
+    expect(provider.toNostrTag(contentId)).toEqual([`audio:track:${audioUrl}`, audioUrl]);
   });
 
   it('contentKind: returns "audio:track"', () => {
-    expect(provider.contentKind()).toBe('audio:track');
+    const contentId = { platform: 'audio', type: 'track', id: audioId };
+    expect(provider.contentKind(contentId)).toBe('audio:track');
   });
 
-  it('toNostrTag()[0] starts with "audio:" platform prefix', () => {
+  it('toNostrTag()[0] prefix matches contentKind()', () => {
     const contentId = { platform: 'audio', type: 'track', id: audioId };
     const [tagValue] = provider.toNostrTag(contentId);
-    // audio tag embeds the raw URL, so prefix is `audio:` (not `audio:track:`)
-    expect(tagValue.startsWith('audio:')).toBe(true);
+    const kind = provider.contentKind(contentId);
+    expect(tagValue.startsWith(`${kind}:`)).toBe(true);
   });
 });
 

--- a/src/shared/nostr/nip05.ts
+++ b/src/shared/nostr/nip05.ts
@@ -45,6 +45,11 @@ function isUnsafeDomain(domain: string): boolean {
   return false;
 }
 
+/**
+ * Fetch and verify a NIP-05 identifier against a pubkey.
+ * @remarks Browser-only — uses browser fetch directly with `isUnsafeDomain` guard.
+ * Do not call from server-side code; use `safeFetch` for server contexts.
+ */
 async function fetchNip05(nip05: string, pubkey: string): Promise<Nip05Result> {
   const atIndex = nip05.indexOf('@');
   if (atIndex === -1 || atIndex === 0 || atIndex === nip05.length - 1) {

--- a/src/web/routes/[platform]/[type]/[id]/PlayerColumn.svelte
+++ b/src/web/routes/[platform]/[type]/[id]/PlayerColumn.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import { createPlayerColumnViewModel } from '$features/content-resolution/ui/player-column-view-model.svelte.js';
+  import PodcastEpisodeList from '$features/content-resolution/ui/PodcastEpisodeList.svelte';
+  import YouTubeFeedList from '$features/content-resolution/ui/YouTubeFeedList.svelte';
   import AudioEmbed from '$lib/components/AudioEmbed.svelte';
-  import PodcastEpisodeList from '$lib/components/PodcastEpisodeList.svelte';
-  import YouTubeFeedList from '$lib/components/YouTubeFeedList.svelte';
   import type { ContentId, ContentProvider } from '$shared/content/types.js';
   import { t } from '$shared/i18n/t.js';
 


### PR DESCRIPTION
## 概要

リリース前総合コードレビューで検出された HIGH/MEDIUM 7件の修正。

- **H-3**: `error-handler.ts` の HTTPException メッセージ漏洩を安全メッセージマッピングに置換
- **M-1**: `audio.ts` の `toNostrTag()`/`contentKind()` で `contentId.type` を使用 (CLAUDE.md/NIP-73 準拠)
- **M-3**: `soundcloud-api-client.ts` に SoundCloud URL バリデーション追加
- **M-4**: `CommentList.svelte` の CSS セレクタ補間を `CSS.escape()` で安全化
- **M-5**: `nip05.ts` の `fetchNip05` に browser-only JSDoc 追加
- **M-6**: `content-resolution → comments` 直接依存を `$shared/browser/comments.ts` facade 経由に変更
- **M-7**: `SoundCloudEmbed`/`YouTubeFeedList`/`PodcastEpisodeList` を `src/lib/components/` → `src/features/content-resolution/ui/` に移動

## テスト計画

- [x] `pnpm format:check` — PASS
- [x] `pnpm lint` — PASS
- [x] `pnpm check` — PASS (1242 files, 0 errors)
- [x] `pnpm test` — PASS (2607/2607)
- [ ] `pnpm test:e2e` — CI で確認
- [x] `pnpm graph:imports:summary` — `lib-components → features` 17→15、`features → features` 3→2 に改善