### PR TITLE
[codex] isolate non-auftakt follow-up changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev:full": "wrangler pages dev --port 5173 --proxy 5174 -- vite dev --port 5174",
     "build": "vite build",
     "preview": "vite preview",
-    "prepare": "svelte-kit sync || echo ''",
+    "prepare": "(svelte-kit sync || echo '') && simple-git-hooks",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "check:structure": "node scripts/check-structure.mjs",
@@ -55,9 +55,11 @@
     "eslint-plugin-svelte": "^3.16.0",
     "fake-indexeddb": "^6.2.5",
     "globals": "^17.4.0",
+    "nano-staged": "^0.9.0",
     "nostr-typedef": "^0.13.0",
     "prettier": "^3.8.1",
     "prettier-plugin-svelte": "^3.5.1",
+    "simple-git-hooks": "^2.13.1",
     "svelte": "^5.55.0",
     "svelte-check": "^4.4.2",
     "tailwindcss": "^4.2.2",
@@ -90,5 +92,24 @@
       "undici@<6.24.0": ">=6.24.0",
       "cookie@<0.7.0": ">=0.7.0"
     }
+  },
+  "simple-git-hooks": {
+    "pre-commit": "pnpm nano-staged"
+  },
+  "nano-staged": {
+    "*.{ts,js,svelte}": [
+      "prettier --write",
+      "eslint --fix"
+    ],
+    "**/*.{ts,js,svelte}": [
+      "prettier --write",
+      "eslint --fix"
+    ],
+    "*.{json,md,yml,yaml}": [
+      "prettier --write"
+    ],
+    "**/*.{json,md,yml,yaml}": [
+      "prettier --write"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -97,16 +97,9 @@
     "pre-commit": "pnpm nano-staged"
   },
   "nano-staged": {
-    "*.{ts,js,svelte}": [
-      "prettier --write",
-      "eslint --fix"
-    ],
     "**/*.{ts,js,svelte}": [
       "prettier --write",
       "eslint --fix"
-    ],
-    "*.{json,md,yml,yaml}": [
-      "prettier --write"
     ],
     "**/*.{json,md,yml,yaml}": [
       "prettier --write"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,9 @@ importers:
       globals:
         specifier: ^17.4.0
         version: 17.4.0
+      nano-staged:
+        specifier: ^0.9.0
+        version: 0.9.0
       nostr-typedef:
         specifier: ^0.13.0
         version: 0.13.0
@@ -115,6 +118,9 @@ importers:
       prettier-plugin-svelte:
         specifier: ^3.5.1
         version: 3.5.1(prettier@3.8.1)(svelte@5.55.0)
+      simple-git-hooks:
+        specifier: ^2.13.1
+        version: 2.13.1
       svelte:
         specifier: ^5.55.0
         version: 5.55.0
@@ -1776,6 +1782,11 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  nano-staged@0.9.0:
+    resolution: {integrity: sha512-0JfyX4i0Vp5HhC9RDtJ1kp7psz8CFuS3Gya3Z6WZv//QCwA9dPzi1S803VdR0c0P6R7sSvweZ5mSJmYQ/N+loQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -1950,6 +1961,10 @@ packages:
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  simple-git-hooks@2.13.1:
+    resolution: {integrity: sha512-WszCLXwT4h2k1ufIXAgsbiTOazqqevFCIncOuUBZJ91DdvWcC5+OFkluWRQPrcuSYd8fjq+o2y1QfWqYMoAToQ==}
+    hasBin: true
 
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
@@ -3624,6 +3639,10 @@ snapshots:
 
   ms@2.1.3: {}
 
+  nano-staged@0.9.0:
+    dependencies:
+      picocolors: 1.1.1
+
   nanoid@3.3.11: {}
 
   natural-compare@1.4.0: {}
@@ -3808,6 +3827,8 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   siginfo@2.0.0: {}
+
+  simple-git-hooks@2.13.1: {}
 
   sirv@3.0.2:
     dependencies:

--- a/src/features/profiles/ui/profile-page-view-model.svelte.ts
+++ b/src/features/profiles/ui/profile-page-view-model.svelte.ts
@@ -1,6 +1,7 @@
 import { followUser, getFollows, unfollowUser } from '$shared/browser/follows.js';
 import { getMuteList, muteUser } from '$shared/browser/mute.js';
 import { fetchProfile, getProfileDisplay } from '$shared/browser/profile.js';
+import { getAuth } from '$shared/browser/auth.js';
 import { t } from '$shared/i18n/t.js';
 import { decodeNip19 } from '$shared/nostr/nip19-decode.js';
 import { createLogger } from '$shared/utils/logger.js';
@@ -31,6 +32,7 @@ interface ConfirmDialogBinding {
 }
 
 export function createProfilePageViewModel(getProfileId: () => string) {
+  const auth = getAuth();
   const follows = getFollows();
   const muteList = getMuteList();
 
@@ -118,12 +120,14 @@ export function createProfilePageViewModel(getProfileId: () => string) {
   });
 
   $effect(() => {
+    void auth.pubkey;
     const currentPubkey = pubkey;
     if (!currentPubkey) return;
     void fetchProfile(currentPubkey);
   });
 
   $effect(() => {
+    void auth.pubkey;
     const currentPubkey = pubkey;
     if (!currentPubkey) return;
 

--- a/src/features/profiles/ui/profile-page-view-model.svelte.ts
+++ b/src/features/profiles/ui/profile-page-view-model.svelte.ts
@@ -1,7 +1,7 @@
+import { getAuth } from '$shared/browser/auth.js';
 import { followUser, getFollows, unfollowUser } from '$shared/browser/follows.js';
 import { getMuteList, muteUser } from '$shared/browser/mute.js';
 import { fetchProfile, getProfileDisplay } from '$shared/browser/profile.js';
-import { getAuth } from '$shared/browser/auth.js';
 import { t } from '$shared/i18n/t.js';
 import { decodeNip19 } from '$shared/nostr/nip19-decode.js';
 import { createLogger } from '$shared/utils/logger.js';

--- a/src/shared/browser/auth.svelte.ts
+++ b/src/shared/browser/auth.svelte.ts
@@ -12,9 +12,9 @@ let state = $state<AuthState>({ pubkey: null, initialized: false, readOnly: fals
 
 async function onLogin(pubkey: string) {
   log.info('Login', { pubkey: shortHex(pubkey) });
-  state.pubkey = pubkey;
   const { initSession } = await import('$appcore/bootstrap/init-session.js');
   await initSession(pubkey);
+  state.pubkey = pubkey;
 }
 
 let logoutInProgress = false;

--- a/src/shared/browser/auth.test.ts
+++ b/src/shared/browser/auth.test.ts
@@ -124,6 +124,28 @@ describe('nlAuth イベント: login', () => {
     expect(getAuth().pubkey).toBe(TEST_PUBKEY);
     expect(getAuth().loggedIn).toBe(true);
   });
+
+  it('initSession 完了前は pubkey を公開しない', async () => {
+    let resolveInit!: () => void;
+    const { getAuth, initAuth } = await import('./auth.svelte.js');
+    const { initSession } = await import('$appcore/bootstrap/init-session.js');
+    (initSession as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveInit = resolve;
+        })
+    );
+    await initAuth();
+
+    dispatchNlAuth('login');
+    await vi.waitUntil(() => (initSession as ReturnType<typeof vi.fn>).mock.calls.length > 0);
+
+    expect(getAuth().pubkey).toBeNull();
+
+    resolveInit();
+    await vi.waitUntil(() => getAuth().pubkey !== null);
+    expect(getAuth().pubkey).toBe(TEST_PUBKEY);
+  });
 });
 
 describe('nlAuth イベント: logout', () => {
@@ -159,6 +181,7 @@ describe('nlAuth イベント: logout', () => {
 
   it('login → logout → login で再ログインできる', async () => {
     const { getAuth, initAuth } = await import('./auth.svelte.js');
+    const { destroySession } = await import('$appcore/bootstrap/init-session.js');
     await initAuth();
 
     dispatchNlAuth('login');
@@ -166,6 +189,7 @@ describe('nlAuth イベント: logout', () => {
 
     dispatchNlAuth('logout');
     await vi.waitUntil(() => getAuth().pubkey === null);
+    await vi.waitUntil(() => (destroySession as ReturnType<typeof vi.fn>).mock.calls.length > 0);
 
     dispatchNlAuth('login');
     await vi.waitUntil(() => getAuth().pubkey !== null);

--- a/src/shared/browser/auth.test.ts
+++ b/src/shared/browser/auth.test.ts
@@ -129,12 +129,10 @@ describe('nlAuth イベント: login', () => {
     let resolveInit!: () => void;
     const { getAuth, initAuth } = await import('./auth.svelte.js');
     const { initSession } = await import('$appcore/bootstrap/init-session.js');
-    (initSession as ReturnType<typeof vi.fn>).mockImplementationOnce(
-      () =>
-        new Promise<void>((resolve) => {
-          resolveInit = resolve;
-        })
-    );
+    const initPromise = new Promise<void>((resolve) => {
+      resolveInit = resolve;
+    });
+    (initSession as ReturnType<typeof vi.fn>).mockReturnValueOnce(initPromise);
     await initAuth();
 
     dispatchNlAuth('login');


### PR DESCRIPTION
## What changed

This PR extracts the changes from the `feat/auftakt-migration` branch that are not inherently tied to the `@ikuradon/auftakt` migration.

Included commits:
- `90ce271` `add pre-commit hooks`
- `b46cf35` `serialize auth bootstrap`

## Why

The original branch mixed a large cache-layer migration with a few standalone follow-up improvements. This PR keeps the independent pieces reviewable and mergeable without taking the auftakt migration itself.

## Scope

- add `simple-git-hooks` + `nano-staged` based pre-commit hooks
- ensure `auth.pubkey` is not exposed before `initSession(pubkey)` completes
- make the profile page re-run profile/follow-related effects after login state becomes available
- add auth regression coverage for the login timing change

## Impact

- repository tooling gets the same pre-commit hook setup already validated on the migration branch
- login bootstrap avoids exposing authenticated state before session initialization finishes
- profile pages no longer miss the post-login refresh triggered by auth state publication timing

## Validation

- `pnpm exec vitest run src/shared/browser/auth.test.ts`
- `pnpm check`
- `pnpm format:check`