### PR TITLE
[codex] 入力中のショートカット誤発火を防止

### DIFF
--- a/src/shared/browser/keyboard-shortcuts.svelte.ts
+++ b/src/shared/browser/keyboard-shortcuts.svelte.ts
@@ -16,6 +16,40 @@ export interface ShortcutActions {
   showHelp: () => void;
 }
 
+const EDITABLE_SHORTCUT_TAGS = new Set(['INPUT', 'TEXTAREA', 'SELECT']);
+const EDITABLE_SHORTCUT_SELECTOR =
+  'input, textarea, select, [contenteditable]:not([contenteditable="false"]), [role="textbox"]';
+
+function getKeyboardEventTarget(e: KeyboardEvent): EventTarget | null {
+  const path = typeof e.composedPath === 'function' ? e.composedPath() : [];
+  return path[0] ?? e.target;
+}
+
+function isEditableShortcutTarget(target: EventTarget | null): boolean {
+  if (!target || typeof target !== 'object') return false;
+
+  const element = target as {
+    tagName?: string;
+    nodeName?: string;
+    isContentEditable?: boolean;
+    closest?: (selector: string) => Element | null;
+  };
+  const tagName =
+    typeof element.tagName === 'string'
+      ? element.tagName.toUpperCase()
+      : typeof element.nodeName === 'string'
+        ? element.nodeName.toUpperCase()
+        : '';
+
+  if (EDITABLE_SHORTCUT_TAGS.has(tagName)) return true;
+  if (element.isContentEditable === true) return true;
+  if (typeof element.closest === 'function') {
+    return element.closest(EDITABLE_SHORTCUT_SELECTOR) !== null;
+  }
+
+  return false;
+}
+
 export function createKeyboardShortcuts(actions: ShortcutActions) {
   let inputFocused = false;
 
@@ -31,7 +65,7 @@ export function createKeyboardShortcuts(actions: ShortcutActions) {
     }
 
     // Skip single-key shortcuts when typing in input/textarea
-    if (inputFocused) return false;
+    if (inputFocused || isEditableShortcutTarget(getKeyboardEventTarget(e))) return false;
 
     // Shift+S → openShare (must check before 's')
     if (e.key === 'S' && e.shiftKey && !e.ctrlKey && !e.metaKey) {

--- a/src/shared/browser/keyboard-shortcuts.test.ts
+++ b/src/shared/browser/keyboard-shortcuts.test.ts
@@ -45,7 +45,10 @@ describe('createKeyboardShortcuts', () => {
 
   function fireKey(
     key: string,
-    opts: Partial<KeyboardEventInit> & { target?: EventTarget | null } = {}
+    opts: Partial<KeyboardEventInit> & {
+      target?: EventTarget | null;
+      composedPath?: () => EventTarget[];
+    } = {}
   ): boolean {
     const event = {
       key,
@@ -143,6 +146,15 @@ describe('createKeyboardShortcuts', () => {
   it('ignores shortcuts from textarea keydown targets even when focus state is stale', () => {
     const handled = fireKey('f', {
       target: { tagName: 'TEXTAREA' } as unknown as EventTarget
+    });
+
+    expect(handled).toBe(false);
+    expect(actions.switchToFlow).not.toHaveBeenCalled();
+  });
+
+  it('ignores shortcuts from textarea via composedPath even when focus state is stale', () => {
+    const handled = fireKey('f', {
+      composedPath: () => [{ tagName: 'TEXTAREA' } as unknown as EventTarget]
     });
 
     expect(handled).toBe(false);

--- a/src/shared/browser/keyboard-shortcuts.test.ts
+++ b/src/shared/browser/keyboard-shortcuts.test.ts
@@ -43,7 +43,10 @@ describe('createKeyboardShortcuts', () => {
     shortcuts.destroy();
   });
 
-  function fireKey(key: string, opts: Partial<KeyboardEventInit> = {}): boolean {
+  function fireKey(
+    key: string,
+    opts: Partial<KeyboardEventInit> & { target?: EventTarget | null } = {}
+  ): boolean {
     const event = {
       key,
       shiftKey: false,
@@ -134,6 +137,15 @@ describe('createKeyboardShortcuts', () => {
   it('ignores single keys when input is focused', () => {
     shortcuts.setInputFocused(true);
     fireKey('f');
+    expect(actions.switchToFlow).not.toHaveBeenCalled();
+  });
+
+  it('ignores shortcuts from textarea keydown targets even when focus state is stale', () => {
+    const handled = fireKey('f', {
+      target: { tagName: 'TEXTAREA' } as unknown as EventTarget
+    });
+
+    expect(handled).toBe(false);
     expect(actions.switchToFlow).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## 概要

- keyboard shortcut handler が `KeyboardEvent.target` を確認し、`input` / `textarea` / `select` / `contenteditable` / `role="textbox"` 由来の keydown を無視するようにしました。
- focus tracking が stale な場合でも textarea 入力中に `f` などのショートカットが発火しない回帰テストを追加しました。

## 根本原因

既存実装は `CommentList` 側の `inputFocused` フラグだけで入力中かどうかを判定していました。そのためフォーカス状態が stale になると、入力要素から bubble した `keydown` でもショートカット処理が実行されていました。

## 確認

- `pnpm exec vitest run src/shared/browser/keyboard-shortcuts.test.ts`
- `pnpm run check`
