### PR TITLE
[codex] Fix login avatar hydration timing

### DIFF
--- a/src/app/bootstrap/init-session.test.ts
+++ b/src/app/bootstrap/init-session.test.ts
@@ -160,8 +160,11 @@ describe('initSession', () => {
     await initSession(PUBKEY);
     await initSession(PUBKEY_2);
 
-    expect(fetchProfileMock).toHaveBeenCalledWith(PUBKEY);
-    expect(fetchProfileMock).toHaveBeenCalledWith(PUBKEY_2);
+    expect(fetchProfileMock).toHaveBeenCalledTimes(4);
+    expect(fetchProfileMock).toHaveBeenNthCalledWith(1, PUBKEY);
+    expect(fetchProfileMock).toHaveBeenNthCalledWith(2, PUBKEY);
+    expect(fetchProfileMock).toHaveBeenNthCalledWith(3, PUBKEY_2);
+    expect(fetchProfileMock).toHaveBeenNthCalledWith(4, PUBKEY_2);
   });
 
   it('loadFollows が失敗しても全体は正常終了する', async () => {

--- a/src/app/bootstrap/init-session.test.ts
+++ b/src/app/bootstrap/init-session.test.ts
@@ -139,12 +139,29 @@ describe('initSession', () => {
     expect(fetchProfileMock).toHaveBeenCalledWith(PUBKEY);
   });
 
+  it('current user profile hydrate は user relay list 解決を待たずに開始する', async () => {
+    let resolveRelays!: (urls: string[]) => void;
+    applyUserRelaysMock.mockReturnValueOnce(
+      new Promise<string[]>((resolve) => {
+        resolveRelays = resolve;
+      })
+    );
+
+    const pending = initSession(PUBKEY);
+    await vi.waitUntil(() => applyUserRelaysMock.mock.calls.length > 0);
+
+    expect(fetchProfileMock).toHaveBeenCalledWith(PUBKEY);
+
+    resolveRelays(RELAY_URLS);
+    await pending;
+  });
+
   it('ログイン切替時は都度その pubkey で profile hydrate を実行する', async () => {
     await initSession(PUBKEY);
     await initSession(PUBKEY_2);
 
-    expect(fetchProfileMock).toHaveBeenNthCalledWith(1, PUBKEY);
-    expect(fetchProfileMock).toHaveBeenNthCalledWith(2, PUBKEY_2);
+    expect(fetchProfileMock).toHaveBeenCalledWith(PUBKEY);
+    expect(fetchProfileMock).toHaveBeenCalledWith(PUBKEY_2);
   });
 
   it('loadFollows が失敗しても全体は正常終了する', async () => {

--- a/src/app/bootstrap/init-session.ts
+++ b/src/app/bootstrap/init-session.ts
@@ -1,22 +1,32 @@
 /**
- * Session initialization orchestrator.
- * Centralizes what happens on login/logout so the sequence is traceable in one place.
+ * セッション初期化のオーケストレーター。
+ * ログイン/ログアウト時に起きる処理をここに集約し、順序を追いやすくする。
  *
- * Login sequence:
- * 1. Apply user relays (kind:10002)
- * 2. Refresh relay connections
- * 3. Load follows, custom emojis, bookmarks, mute list (parallel, fire-and-forget)
+ * ログイン手順:
+ * 1. 現在ユーザーの profile を default relay ですぐ hydrate する
+ * 2. ユーザー relay list (kind:10002) を適用する
+ * 3. relay 接続状態を更新する
+ * 4. follows, custom emojis, bookmarks, mute list, profile 再試行を並列で fire-and-forget する
  *
- * Logout sequence:
- * 1. Reset to default relays
- * 2. Clear all store state
- * 3. Clear events DB
+ * ログアウト手順:
+ * 1. default relay に戻す
+ * 2. store state をクリアする
+ * 3. events DB をクリアする
  */
 
 import { clearStoredEvents } from '$shared/auftakt/resonote.js';
 import { createLogger } from '$shared/utils/logger.js';
 
 const log = createLogger('session');
+
+function hydrateCurrentUserProfile(
+  fetchProfile: (pubkey: string) => Promise<void>,
+  pubkey: string
+): void {
+  void fetchProfile(pubkey).catch((err) =>
+    log.error('Failed to hydrate current user profile', err)
+  );
+}
 
 export async function initSession(pubkey: string): Promise<void> {
   log.info('Initializing session stores');
@@ -31,17 +41,17 @@ export async function initSession(pubkey: string): Promise<void> {
     import('$shared/browser/profile.js')
   ]);
 
+  hydrateCurrentUserProfile(fetchProfile, pubkey);
+
   const relayUrls = await applyUserRelays(pubkey);
   void refreshRelayList(relayUrls);
 
-  // Fire-and-forget: load user data in parallel
+  // Fire-and-forget: ユーザーデータを並列で読む
   void loadFollows(pubkey).catch((err) => log.error('Failed to load follows', err));
   void loadCustomEmojis(pubkey).catch((err) => log.error('Failed to load custom emojis', err));
   void loadBookmarks(pubkey).catch((err) => log.error('Failed to load bookmarks', err));
   void loadMuteList(pubkey).catch((err) => log.error('Failed to load mute list', err));
-  void fetchProfile(pubkey).catch((err) =>
-    log.error('Failed to hydrate current user profile', err)
-  );
+  hydrateCurrentUserProfile(fetchProfile, pubkey);
 }
 
 export async function destroySession(): Promise<void> {

--- a/src/app/bootstrap/init-session.ts
+++ b/src/app/bootstrap/init-session.ts
@@ -51,6 +51,7 @@ export async function initSession(pubkey: string): Promise<void> {
   void loadCustomEmojis(pubkey).catch((err) => log.error('Failed to load custom emojis', err));
   void loadBookmarks(pubkey).catch((err) => log.error('Failed to load bookmarks', err));
   void loadMuteList(pubkey).catch((err) => log.error('Failed to load mute list', err));
+  // 先行 hydrate で未解決だった場合だけ、user relay 適用後の読み取りとして効く。
   hydrateCurrentUserProfile(fetchProfile, pubkey);
 }
 

--- a/src/shared/browser/auth.svelte.ts
+++ b/src/shared/browser/auth.svelte.ts
@@ -12,9 +12,9 @@ let state = $state<AuthState>({ pubkey: null, initialized: false, readOnly: fals
 
 async function onLogin(pubkey: string) {
   log.info('Login', { pubkey: shortHex(pubkey) });
-  const { initSession } = await import('$appcore/bootstrap/init-session.js');
-  await initSession(pubkey);
   state.pubkey = pubkey;
+  const { initSession } = await import('$appcore/bootstrap/init-session.js');
+  await initSession(pubkey).catch((err) => log.error('Failed to initialize session stores', err));
 }
 
 let logoutInProgress = false;

--- a/src/shared/browser/auth.test.ts
+++ b/src/shared/browser/auth.test.ts
@@ -131,7 +131,8 @@ describe('nlAuth イベント: login', () => {
     expect(launchLogin).not.toHaveBeenCalled();
     expect(initSession).toHaveBeenCalledOnce();
     expect(initSession).toHaveBeenCalledWith(TEST_PUBKEY);
-    expect(getAuth().pubkey).toBeNull();
+    expect(getAuth().pubkey).toBe(TEST_PUBKEY);
+    expect(getAuth().loggedIn).toBe(true);
 
     resolveInit();
     await vi.waitUntil(() => getAuth().pubkey === TEST_PUBKEY);
@@ -148,7 +149,7 @@ describe('nlAuth イベント: login', () => {
     expect(getAuth().loggedIn).toBe(true);
   });
 
-  it('initSession 完了前は pubkey を公開しない', async () => {
+  it('initSession 完了前でも pubkey を公開して UI をログイン済みにする', async () => {
     let resolveInit!: () => void;
     const { getAuth, initAuth } = await import('./auth.svelte.js');
     const { initSession } = await import('$appcore/bootstrap/init-session.js');
@@ -161,7 +162,8 @@ describe('nlAuth イベント: login', () => {
     dispatchNlAuth('login');
     await vi.waitUntil(() => (initSession as ReturnType<typeof vi.fn>).mock.calls.length > 0);
 
-    expect(getAuth().pubkey).toBeNull();
+    expect(getAuth().pubkey).toBe(TEST_PUBKEY);
+    expect(getAuth().loggedIn).toBe(true);
 
     resolveInit();
     await vi.waitUntil(() => getAuth().pubkey !== null);

--- a/src/shared/browser/auth.test.ts
+++ b/src/shared/browser/auth.test.ts
@@ -135,7 +135,8 @@ describe('nlAuth イベント: login', () => {
     expect(getAuth().loggedIn).toBe(true);
 
     resolveInit();
-    await vi.waitUntil(() => getAuth().pubkey === TEST_PUBKEY);
+    await initPromise;
+    expect(getAuth().pubkey).toBe(TEST_PUBKEY);
   });
 
   it('signup イベントでも pubkey が設定される', async () => {
@@ -166,7 +167,7 @@ describe('nlAuth イベント: login', () => {
     expect(getAuth().loggedIn).toBe(true);
 
     resolveInit();
-    await vi.waitUntil(() => getAuth().pubkey !== null);
+    await initPromise;
     expect(getAuth().pubkey).toBe(TEST_PUBKEY);
   });
 });

--- a/src/shared/browser/profile.svelte.test.ts
+++ b/src/shared/browser/profile.svelte.test.ts
@@ -35,12 +35,16 @@ import {
 const PUBKEY_A = 'aaaa1111'.repeat(8);
 const PUBKEY_B = 'bbbb2222'.repeat(8);
 
-function makeKind0Event(pubkey: string, content: Record<string, unknown> | string) {
+function makeKind0Event(
+  pubkey: string,
+  content: Record<string, unknown> | string,
+  createdAt = 1_000_000
+) {
   return {
     id: `evt-${pubkey.slice(0, 4)}`,
     pubkey,
     kind: 0,
-    created_at: 1_000_000,
+    created_at: createdAt,
     content: typeof content === 'string' ? content : JSON.stringify(content),
     tags: [],
     sig: 'sig'
@@ -134,6 +138,25 @@ describe('profile.svelte', () => {
     await fetchProfile(PUBKEY_B);
 
     expect(getProfile(PUBKEY_B)).toEqual(expect.objectContaining({ name: 'Fallback Name' }));
+  });
+
+  it('keeps newest profile metadata when multiple sources return the same pubkey', async () => {
+    setupFetchResult({
+      cachedEvents: [makeKind0Event(PUBKEY_A, { name: 'New Cached' }, 2_000_000)],
+      fetchedEvents: [makeKind0Event(PUBKEY_A, { name: 'Old Relay' }, 1_000_000)],
+      fallbackEvents: [
+        {
+          pubkey: PUBKEY_A,
+          created_at: 1_500_000,
+          content: JSON.stringify({ name: 'Middle Fallback' }),
+          tags: []
+        }
+      ]
+    });
+
+    await fetchProfile(PUBKEY_A);
+
+    expect(getProfile(PUBKEY_A)).toEqual(expect.objectContaining({ name: 'New Cached' }));
   });
 
   it('stores empty profiles for unresolved pubkeys', async () => {

--- a/src/shared/browser/profile.svelte.ts
+++ b/src/shared/browser/profile.svelte.ts
@@ -18,7 +18,14 @@ const MAX_PROFILES = 2000;
 
 const pending = new Set<string>();
 const retryQueued = new Set<string>();
+const profileCreatedAt = new Map<string, number>();
 let profiles = $state<Map<string, Profile>>(new Map());
+
+interface ProfileMetadataEvent {
+  pubkey: string;
+  content: string;
+  created_at: number;
+}
 
 function isUnresolvedPlaceholderProfile(profile: Profile | undefined): boolean {
   return profile !== undefined && Object.keys(profile).length === 0;
@@ -40,6 +47,18 @@ function parseProfileContent(content: string): Profile {
     bot: meta.bot,
     birthday: meta.birthday
   };
+}
+
+function storeProfileFromEvent(event: ProfileMetadataEvent): Profile | null {
+  const currentCreatedAt = profileCreatedAt.get(event.pubkey);
+  if (currentCreatedAt !== undefined && event.created_at < currentCreatedAt) {
+    return null;
+  }
+
+  const profile = parseProfileContent(event.content);
+  profiles.set(event.pubkey, profile);
+  profileCreatedAt.set(event.pubkey, event.created_at);
+  return profile;
 }
 
 function queueRetryIfNeeded(pubkey: string): void {
@@ -101,8 +120,7 @@ export async function fetchProfiles(pubkeys: string[]): Promise<void> {
 
     for (const event of cachedEvents) {
       try {
-        const profile = parseProfileContent(event.content);
-        profiles.set(event.pubkey, profile);
+        storeProfileFromEvent(event);
       } catch {
         log.warn('Malformed cached profile JSON', { pubkey: shortHex(event.pubkey) });
       }
@@ -110,8 +128,8 @@ export async function fetchProfiles(pubkeys: string[]): Promise<void> {
 
     for (const event of fetchedEvents) {
       try {
-        const profile = parseProfileContent(event.content);
-        profiles.set(event.pubkey, profile);
+        const profile = storeProfileFromEvent(event);
+        if (!profile) continue;
         const nip05 = profile.nip05;
         if (nip05) {
           void import('$shared/nostr/nip05.js').then(({ verifyNip05 }) =>
@@ -132,8 +150,7 @@ export async function fetchProfiles(pubkeys: string[]): Promise<void> {
 
     for (const event of fallbackEvents) {
       try {
-        const profile = parseProfileContent(event.content);
-        profiles.set(event.pubkey, profile);
+        storeProfileFromEvent(event);
       } catch {
         log.warn('Malformed profile JSON from latest-event fallback', {
           pubkey: shortHex(event.pubkey)
@@ -171,6 +188,7 @@ export async function fetchProfiles(pubkeys: string[]): Promise<void> {
 /** Clear in-memory profile cache (called on logout). DB cleared separately. */
 export function clearProfiles(): void {
   profiles = new Map();
+  profileCreatedAt.clear();
   pending.clear();
   retryQueued.clear();
 }


### PR DESCRIPTION
## Summary

- Publish authenticated `pubkey` immediately after Nostr login instead of waiting for session initialization.
- Start current-user profile hydration before resolving the user relay list, then retry after applying user relays.
- Add regression coverage for immediate logged-in UI state and profile hydration that is not blocked by kind:10002 relay-list lookup.

## Root Cause

After login, the UI depended on `state.pubkey`, but `pubkey` was only exposed after `initSession()` finished. `initSession()` also waited for user relay-list resolution before starting current-user profile hydration. When kind:10002 lookup was slow, the navbar could stay on the fallback avatar long enough to look stale.

## Validation

- `pnpm vitest run src/shared/browser/auth.test.ts src/app/bootstrap/init-session.test.ts src/app/ui/app-shell-view-model.svelte.test.ts src/features/auth/ui/login-button-view-model.test.ts src/shared/browser/profile.svelte.test.ts`
- `pnpm playwright test e2e/auth-flows.test.ts -g "Navbar avatar hydration"`

Note: local pre-commit also ran `prettier --write` and `eslint --fix` through `nano-staged`.