### PR TITLE
[codex] Fix relay URL canonicalization

### DIFF
--- a/packages/runtime/src/relay-session.contract.test.ts
+++ b/packages/runtime/src/relay-session.contract.test.ts
@@ -798,7 +798,7 @@ describe('relay replay request identity contract', () => {
     session.dispose();
   });
 
-  it('keeps normalized default relay selections open after backward request completion', async () => {
+  it('reuses the default relay URL for normalized default relay selections', async () => {
     const normalizedRelayUrl = `${RELAY_URL}/`;
     const session = createRelaySession({
       defaultRelays: [RELAY_URL],
@@ -829,11 +829,9 @@ describe('relay replay request identity contract', () => {
     req.emit({ kinds: [1] });
     req.over();
 
-    await waitUntil(() =>
-      FakeWebSocket.instances.some((socket) => socket.url === normalizedRelayUrl)
-    );
-    const socket = FakeWebSocket.instances.find((entry) => entry.url === normalizedRelayUrl);
-    if (!socket) throw new Error('normalized default socket was not created');
+    await waitUntil(() => FakeWebSocket.instances.some((socket) => socket.url === RELAY_URL));
+    const socket = FakeWebSocket.instances.find((entry) => entry.url === RELAY_URL);
+    if (!socket) throw new Error('default socket was not created');
     socket.open();
     await waitUntil(() => socket.sent.length > 0);
 
@@ -844,9 +842,54 @@ describe('relay replay request identity contract', () => {
     await new Promise((resolve) => setTimeout(resolve, 30));
 
     expect(socket.readyState).toBe(FakeWebSocket.OPEN);
+    expect(session.getRelayStatus(RELAY_URL)?.connection).toBe('open');
     expect(session.getRelayStatus(normalizedRelayUrl)?.connection).toBe('open');
 
     sub.unsubscribe();
+    session.dispose();
+  });
+
+  it('keeps an existing normalized temporary socket canonical when promoted to default', async () => {
+    const normalizedRelayUrl = `${RELAY_URL}/`;
+    const session = createRelaySession({
+      defaultRelays: [],
+      eoseTimeout: 100
+    });
+    const temporaryReq = createBackwardReq({
+      requestKey: 'rq:v1:contract-temporary-normalized-before-default' as RequestKey
+    });
+    const defaultReq = createBackwardReq({
+      requestKey: 'rq:v1:contract-default-after-temporary-normalized' as RequestKey
+    });
+
+    const temporarySub = session
+      .use(temporaryReq, {
+        on: {
+          defaultReadRelays: false,
+          relays: [normalizedRelayUrl]
+        }
+      })
+      .subscribe({});
+    temporaryReq.emit({ kinds: [1] });
+    temporaryReq.over();
+
+    await waitUntil(() =>
+      FakeWebSocket.instances.some((socket) => socket.url === normalizedRelayUrl)
+    );
+    const socket = FakeWebSocket.instances.find((entry) => entry.url === normalizedRelayUrl);
+    if (!socket) throw new Error('temporary socket was not created');
+
+    session.setDefaultRelays([RELAY_URL]);
+    const defaultSub = session.use(defaultReq).subscribe({});
+    defaultReq.emit({ kinds: [1] });
+    defaultReq.over();
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(FakeWebSocket.instances.map((entry) => entry.url)).toEqual([normalizedRelayUrl]);
+
+    defaultSub.unsubscribe();
+    temporarySub.unsubscribe();
     session.dispose();
   });
 

--- a/packages/runtime/src/relay-session.contract.test.ts
+++ b/packages/runtime/src/relay-session.contract.test.ts
@@ -1625,6 +1625,57 @@ describe('relay replay request identity contract', () => {
     session.dispose();
   });
 
+  it('resolves negentropy responses from a canonicalized relay URL', async () => {
+    const normalizedRelayUrl = `${RELAY_URL}/`;
+    const session = createRelaySession({
+      defaultRelays: [],
+      eoseTimeout: 100
+    });
+
+    const warmup = session.requestCount({
+      relayUrl: normalizedRelayUrl,
+      filters: [{ kinds: [1] }],
+      timeoutMs: 100
+    });
+
+    await waitUntil(() =>
+      FakeWebSocket.instances.some((socket) => socket.url === normalizedRelayUrl)
+    );
+    const socket = FakeWebSocket.instances.find((entry) => entry.url === normalizedRelayUrl);
+    if (!socket) throw new Error('canonical socket was not created');
+    socket.open();
+    await waitUntil(() => socket.sent.length > 0);
+
+    const countPacket = socket.sent[0] as [string, string, Record<string, unknown>];
+    socket.message(['COUNT', countPacket[1], { count: 1 }]);
+    await expect(warmup).resolves.toEqual({ capability: 'supported', count: 1 });
+
+    const pending = session.requestNegentropySync({
+      relayUrl: RELAY_URL,
+      filter: { kinds: [1], authors: ['pubkey-a'] },
+      initialMessageHex: '6100000200',
+      timeoutMs: 100
+    });
+
+    await waitUntil(() =>
+      socket.sent.some((packet) => Array.isArray(packet) && packet[0] === 'NEG-OPEN')
+    );
+    const openPacket = socket.sent.find(
+      (packet): packet is [string, string, Record<string, unknown>, string] =>
+        Array.isArray(packet) && packet[0] === 'NEG-OPEN'
+    );
+    if (!openPacket) throw new Error('NEG-OPEN packet was not sent');
+    socket.message(['NEG-MSG', openPacket[1], '6100000201']);
+
+    await expect(pending).resolves.toEqual({
+      capability: 'supported',
+      messageHex: '6100000201'
+    });
+    expect(FakeWebSocket.instances.map((entry) => entry.url)).toEqual([normalizedRelayUrl]);
+
+    session.dispose();
+  });
+
   it('sends NIP-45 COUNT requests and resolves count responses', async () => {
     const session = createRelaySession({
       defaultRelays: [RELAY_URL],
@@ -1656,6 +1707,51 @@ describe('relay replay request identity contract', () => {
       approximate: true,
       hll
     });
+
+    session.dispose();
+  });
+
+  it('resolves NIP-45 COUNT responses from a canonicalized relay URL', async () => {
+    const normalizedRelayUrl = `${RELAY_URL}/`;
+    const session = createRelaySession({
+      defaultRelays: [],
+      eoseTimeout: 100
+    });
+
+    const warmup = session.requestCount({
+      relayUrl: normalizedRelayUrl,
+      filters: [{ kinds: [1] }],
+      timeoutMs: 100
+    });
+
+    await waitUntil(() =>
+      FakeWebSocket.instances.some((socket) => socket.url === normalizedRelayUrl)
+    );
+    const socket = FakeWebSocket.instances.find((entry) => entry.url === normalizedRelayUrl);
+    if (!socket) throw new Error('canonical socket was not created');
+    socket.open();
+    await waitUntil(() => socket.sent.length > 0);
+
+    const warmupPacket = socket.sent[0] as [string, string, Record<string, unknown>];
+    socket.message(['COUNT', warmupPacket[1], { count: 1 }]);
+    await expect(warmup).resolves.toEqual({ capability: 'supported', count: 1 });
+
+    const pending = session.requestCount({
+      relayUrl: RELAY_URL,
+      filters: [{ kinds: [7], '#e': ['target-event'] }],
+      timeoutMs: 100
+    });
+
+    await waitUntil(() => socket.sent.length >= 2);
+    const countPacket = socket.sent.at(-1) as [string, string, Record<string, unknown>];
+    expect(countPacket[0]).toBe('COUNT');
+    socket.message(['COUNT', countPacket[1], { count: 12 }]);
+
+    await expect(pending).resolves.toEqual({
+      capability: 'supported',
+      count: 12
+    });
+    expect(FakeWebSocket.instances.map((entry) => entry.url)).toEqual([normalizedRelayUrl]);
 
     session.dispose();
   });

--- a/packages/runtime/src/relay-session.ts
+++ b/packages/runtime/src/relay-session.ts
@@ -1116,6 +1116,7 @@ class RelaySession implements RelaySessionApi {
     options: NegentropyRequestOptions
   ): Promise<NegentropyTransportResult> {
     const relay = this.getConnection(options.relayUrl);
+    const relayUrl = relay.url;
     const subId = createNegentropySubId();
 
     try {
@@ -1142,7 +1143,7 @@ class RelaySession implements RelaySessionApi {
 
       const messageSub = this.messages.subscribe({
         next: ({ from, message }) => {
-          if (from !== options.relayUrl || !Array.isArray(message)) return;
+          if (from !== relayUrl || !Array.isArray(message)) return;
           const [type, incomingSubId] = message as [string, string, ...unknown[]];
           if (incomingSubId !== subId) return;
 
@@ -1166,7 +1167,7 @@ class RelaySession implements RelaySessionApi {
 
       const stateSub = this.states.subscribe({
         next: (packet) => {
-          if (packet.from !== options.relayUrl) return;
+          if (packet.from !== relayUrl) return;
           if (
             packet.state === 'backoff' ||
             packet.state === 'closed' ||
@@ -1206,6 +1207,7 @@ class RelaySession implements RelaySessionApi {
     }
 
     const relay = this.getConnection(options.relayUrl);
+    const relayUrl = relay.url;
     const subId = createCountSubId();
 
     try {
@@ -1231,7 +1233,7 @@ class RelaySession implements RelaySessionApi {
 
       const messageSub = this.messages.subscribe({
         next: ({ from, message }) => {
-          if (from !== options.relayUrl || !Array.isArray(message)) return;
+          if (from !== relayUrl || !Array.isArray(message)) return;
           const [type, incomingSubId] = message as [string, string, ...unknown[]];
           if (incomingSubId !== subId) return;
 
@@ -1258,7 +1260,7 @@ class RelaySession implements RelaySessionApi {
 
       const stateSub = this.states.subscribe({
         next: (packet) => {
-          if (packet.from !== options.relayUrl) return;
+          if (packet.from !== relayUrl) return;
           if (
             packet.state === 'backoff' ||
             packet.state === 'closed' ||

--- a/packages/runtime/src/relay-session.ts
+++ b/packages/runtime/src/relay-session.ts
@@ -445,6 +445,7 @@ interface RelayAuthState {
 class RelaySession implements RelaySessionApi {
   private readonly defaultRelays = new Map<string, DefaultRelayConfig>();
   private readonly defaultRelayKeys = new Set<string>();
+  private readonly relayUrlsByKey = new Map<string, string>();
   private readonly connections = new Map<string, RelaySocket>();
   private readonly messages = new Subject<{ from: string; message: unknown }>();
   private readonly states = new Subject<ConnectionStatePacket>();
@@ -487,29 +488,36 @@ class RelaySession implements RelaySessionApi {
       const key = normalizeRelaySessionKey(relay);
       if (nextByKey.has(key)) continue;
       nextByKey.set(key, { url: relay, read: true, write: true });
-      this.registerRelayLifecyclePolicy(relay, 'lazy-keep');
     }
     const nextKeys = new Set(nextByKey.keys());
+    const retainedConnectionUrlsByKey = new Map<string, string>();
 
     for (const [url, connection] of this.connections.entries()) {
-      if (!nextKeys.has(normalizeRelaySessionKey(url))) {
+      const key = normalizeRelaySessionKey(url);
+      if (!nextKeys.has(key)) {
         connection.close();
         this.relayLifecyclePolicies.delete(url);
         this.connections.delete(url);
+      } else {
+        retainedConnectionUrlsByKey.set(key, url);
       }
     }
 
     this.defaultRelays.clear();
     this.defaultRelayKeys.clear();
+    this.relayUrlsByKey.clear();
     for (const [key, config] of nextByKey.entries()) {
       const url = config.url;
+      const relayUrl = retainedConnectionUrlsByKey.get(key) ?? url;
       this.defaultRelays.set(url, config);
       this.defaultRelayKeys.add(key);
+      this.relayUrlsByKey.set(key, relayUrl);
+      this.registerRelayLifecyclePolicy(relayUrl, 'lazy-keep');
     }
   }
 
   getRelayStatus(url: string): RelayStatus | undefined {
-    const relay = this.relayObservations.get(url);
+    const relay = this.relayObservations.get(this.resolveRelaySessionUrl(url));
     if (!relay) return undefined;
     return {
       connection: relay.connection,
@@ -1670,31 +1678,44 @@ class RelaySession implements RelaySessionApi {
   }
 
   private registerRelayLifecyclePolicy(url: string, mode: RelayLifecycleMode): void {
-    const current = this.relayLifecyclePolicies.get(url);
+    const relayUrl = this.resolveRelaySessionUrl(url);
+    const current = this.relayLifecyclePolicies.get(relayUrl);
     if (current?.mode === mode) return;
 
     const policy =
       mode === 'lazy-keep'
         ? this.relayLifecycleOptions.defaultRelay
         : this.relayLifecycleOptions.temporaryRelay;
-    this.relayLifecyclePolicies.set(url, policy);
+    this.relayLifecyclePolicies.set(relayUrl, policy);
   }
 
   private isDefaultRelayUrl(url: string): boolean {
     return this.defaultRelayKeys.has(normalizeRelaySessionKey(url));
   }
 
+  private rememberRelaySessionUrl(url: string): void {
+    const key = normalizeRelaySessionKey(url);
+    if (!this.relayUrlsByKey.has(key)) {
+      this.relayUrlsByKey.set(key, url);
+    }
+  }
+
+  private resolveRelaySessionUrl(url: string): string {
+    return this.relayUrlsByKey.get(normalizeRelaySessionKey(url)) ?? url;
+  }
+
   private addResolvedRelay(target: Map<string, string>, relay: string): void {
     const key = normalizeRelaySessionKey(relay);
     if (!target.has(key)) {
-      target.set(key, relay);
+      target.set(key, this.resolveRelaySessionUrl(relay));
     }
   }
 
   private getRelayLifecyclePolicy(url: string): RelayLifecyclePolicy {
-    const existing = this.relayLifecyclePolicies.get(url);
+    const relayUrl = this.resolveRelaySessionUrl(url);
+    const existing = this.relayLifecyclePolicies.get(relayUrl);
     if (existing) return existing;
-    this.relayLifecyclePolicies.set(url, this.relayLifecycleOptions.temporaryRelay);
+    this.relayLifecyclePolicies.set(relayUrl, this.relayLifecycleOptions.temporaryRelay);
     return this.relayLifecycleOptions.temporaryRelay;
   }
 
@@ -1709,12 +1730,14 @@ class RelaySession implements RelaySessionApi {
   }
 
   private getConnection(url: string): RelaySocket {
-    let connection = this.connections.get(url);
+    const relayUrl = this.resolveRelaySessionUrl(url);
+    let connection = this.connections.get(relayUrl);
     if (!connection) {
+      this.rememberRelaySessionUrl(relayUrl);
       connection = new RelaySocket(
-        url,
-        () => this.getRelayLifecyclePolicy(url),
-        () => (this.relayGroupKeys.get(url)?.size ?? 0) > 0,
+        relayUrl,
+        () => this.getRelayLifecyclePolicy(relayUrl),
+        () => (this.relayGroupKeys.get(relayUrl)?.size ?? 0) > 0,
         (from, message) => this.handleRelayMessage(from, message),
         (from, state, explicitReason) => {
           const reason =
@@ -1729,8 +1752,8 @@ class RelaySession implements RelaySessionApi {
           this.updateRelayObservation(from, state, reason);
         }
       );
-      this.connections.set(url, connection);
-      this.updateRelayObservation(url, 'idle', 'boot');
+      this.connections.set(relayUrl, connection);
+      this.updateRelayObservation(relayUrl, 'idle', 'boot');
     }
     return connection;
   }


### PR DESCRIPTION
## Summary

- Canonicalize relay session URL lookups by normalized relay key so trailing-slash and non-trailing-slash variants share a connection.
- Preserve an existing retained connection URL when a temporary relay is later promoted to the default relay list.
- Add relay-session contract coverage for default relay reuse and temporary-to-default promotion.

## Root cause

`RelaySession` deduplicated relay selections with `normalizeRelayUrl()` but stored connection, observation, and lifecycle state by the raw URL string. When `wss://relay.example` and `wss://relay.example/` entered through different paths, the session could create or observe duplicate relay entries.

## Validation

- `pnpm exec vitest run packages/runtime/src/relay-session.contract.test.ts packages/runtime/src/relay-observation.contract.test.ts`
- `pnpm run check`
- `git -c core.fsmonitor=false diff --check`