### PR TITLE
fix: ログイン後に自動的にユーザー設定のリレーに接続されるように修正

### DIFF
--- a/src/app/ui/app-shell-view-model.svelte.ts
+++ b/src/app/ui/app-shell-view-model.svelte.ts
@@ -53,7 +53,7 @@ export function createAppShellViewModel() {
       return;
     }
 
-    void initRelayStatus();
+    void initRelayStatus(auth.pubkey ?? undefined);
     return () => {
       destroyRelayStatus();
     };

--- a/src/shared/browser/relays.svelte.ts
+++ b/src/shared/browser/relays.svelte.ts
@@ -118,6 +118,10 @@ export async function initRelayStatus(pubkey?: string): Promise<void> {
   }
 
   const snapshot = await snapshotRelayStatuses(relayUrls);
+
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (subscription) return;
+
   aggregateState = aggregateStateFromSnapshots(snapshot);
 
   relays = snapshot.map(relaySnapshotToUiState);

--- a/src/shared/browser/relays.svelte.ts
+++ b/src/shared/browser/relays.svelte.ts
@@ -96,10 +96,28 @@ export async function refreshRelayList(urls: string[]): Promise<void> {
   relays = snapshot.map(relaySnapshotToUiState);
 }
 
-export async function initRelayStatus(): Promise<void> {
+export async function initRelayStatus(pubkey?: string): Promise<void> {
   if (subscription) return;
 
-  const snapshot = await snapshotRelayStatuses(DEFAULT_RELAYS);
+  let relayUrls = DEFAULT_RELAYS;
+  if (pubkey) {
+    try {
+      const relayList = await fetchRelayList(pubkey);
+      if (relayList.entries.length > 0) {
+        relayUrls = relayList.entries.map((e) => e.url);
+        log.info('Using user relay list for initialization', {
+          count: relayUrls.length,
+          source: relayList.source
+        });
+      } else {
+        log.info('No user relay list found, using defaults', { pubkey });
+      }
+    } catch (error) {
+      log.warn('Failed to fetch user relay list, using defaults', { error, pubkey });
+    }
+  }
+
+  const snapshot = await snapshotRelayStatuses(relayUrls);
   aggregateState = aggregateStateFromSnapshots(snapshot);
 
   relays = snapshot.map(relaySnapshotToUiState);

--- a/src/shared/browser/relays.test.ts
+++ b/src/shared/browser/relays.test.ts
@@ -4,26 +4,25 @@ const {
   fetchRelayListEventsMock,
   observeRelayStatusesMock,
   snapshotRelayStatusesMock,
-  logInfoMock,
-  logDebugMock
+  fetchRelayListSourcesMock
 } = vi.hoisted(() => ({
   fetchRelayListEventsMock: vi.fn(),
   observeRelayStatusesMock: vi.fn(),
   snapshotRelayStatusesMock: vi.fn(),
-  logInfoMock: vi.fn(),
-  logDebugMock: vi.fn()
+  fetchRelayListSourcesMock: vi.fn()
 }));
 
 vi.mock('$shared/auftakt/resonote.js', () => ({
   fetchRelayListEvents: fetchRelayListEventsMock,
   observeRelayStatuses: observeRelayStatusesMock,
-  snapshotRelayStatuses: snapshotRelayStatusesMock
+  snapshotRelayStatuses: snapshotRelayStatusesMock,
+  fetchRelayListSources: fetchRelayListSourcesMock
 }));
 
 vi.mock('$shared/utils/logger.js', () => ({
   createLogger: () => ({
-    info: logInfoMock,
-    debug: logDebugMock,
+    info: vi.fn(),
+    debug: vi.fn(),
     warn: vi.fn(),
     error: vi.fn()
   })
@@ -288,6 +287,42 @@ describe('initRelayStatus', () => {
     destroyRelayStatus();
 
     expect(gateway.unsubscribe).toHaveBeenCalledOnce();
+  });
+
+  it('pubkeyを渡すとユーザーのリレーリストを使用する', async () => {
+    setupRelayGatewayMocks({
+      'wss://user.relay.com': 'open'
+    });
+    fetchRelayListSourcesMock.mockResolvedValue({
+      relayListEvents: [
+        {
+          id: '1',
+          pubkey: 'user-pubkey',
+          created_at: 1000,
+          kind: 10002,
+          tags: [['r', 'wss://user.relay.com']],
+          content: '',
+          sig: ''
+        }
+      ],
+      followListEvents: []
+    });
+
+    await initRelayStatus('user-pubkey-123');
+
+    expect(snapshotRelayStatusesMock).toHaveBeenCalledWith(['wss://user.relay.com']);
+  });
+
+  it('fetchRelayList失敗時はDEFAULT_RELAYSにフォールバック', async () => {
+    setupRelayGatewayMocks();
+    fetchRelayListSourcesMock.mockRejectedValue(new Error('Network error'));
+
+    await initRelayStatus('user-pubkey-123');
+
+    expect(snapshotRelayStatusesMock).toHaveBeenCalledWith([
+      'wss://relay.damus.io',
+      'wss://yabu.me'
+    ]);
   });
 
   it('runtime aggregate state を参照できる', async () => {


### PR DESCRIPTION
## 問題
ログイン後、しばらく待ってもユーザー設定のリレーに自動接続されない。設定画面を開くと接続される。

## 原因
- `initRelayStatus()` が `DEFAULT_RELAYS`（デフォルトリレー）のみを使って初期化していた
- ユーザーの kind:10002 リレーリストをログイン時に取得していなかった
- 設定画面を開くと `useCachedLatest()` が発火しリレーが更新されるため、設定画面を開くと接続される現象が起きていた

## 修正内容

### `src/shared/browser/relays.svelte.ts`
- `initRelayStatus()` に `pubkey` パラメータを追加
- pubkey が提供された場合、`fetchRelayList(pubkey)` でユーザーのリレーリストを取得
- リレーリストが取得できたらそれを使用、失敗時は `DEFAULT_RELAYS` をフォールバック

### `src/app/ui/app-shell-view-model.svelte.ts`
- `initRelayStatus()` 呼び出し時に `auth.pubkey` を渡すように変更

## 検証
- LSP診断: エラーなし
- リレーテスト: 15件すべてパス ✅

## 影響範囲
- ログイン時のリレー初期化処理のみ
- 後方互換性あり（pubkey パラメータは省略可能）