### PR TITLE
feat(ci): add automated version bump and release workflows

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,78 @@
+name: Bump Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: 'Version bump type'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '20'
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump version
+        id: bump
+        run: |
+          # Bump version without creating git tag
+          npm version ${{ github.event.inputs.version_type }} --no-git-tag-version
+
+          # Get new version
+          NEW_VERSION=$(node -p "require('./package.json').version")
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "branch_name=release/v$NEW_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Create release branch
+        run: |
+          git checkout -b ${{ steps.bump.outputs.branch_name }}
+          git add package.json package-lock.json
+          git commit -m "chore: bump version to ${{ steps.bump.outputs.new_version }}"
+          git push origin ${{ steps.bump.outputs.branch_name }}
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@4e1beaa7521e8b457b572c090b25bd3db56bf1c5 # v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ steps.bump.outputs.branch_name }}
+          title: 'chore: bump version to ${{ steps.bump.outputs.new_version }}'
+          body: |
+            ## Version Bump
+
+            - **Version:** ${{ steps.bump.outputs.new_version }}
+            - **Type:** ${{ github.event.inputs.version_type }}
+
+            ### Changes
+            - Updated `package.json` version
+            - Updated `package-lock.json`
+
+            ### After Merge
+            This PR will automatically create:
+            - Git tag `v${{ steps.bump.outputs.new_version }}`
+            - GitHub Release with generated notes
+          base: main
+          delete-branch: true

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -71,13 +71,13 @@ jobs:
             --title "chore: bump version to $NEW_VERSION" \
             --body "## Version Bump
 
-- **Version:** $NEW_VERSION
-- **Type:** $VERSION_TYPE
+          - **Version:** $NEW_VERSION
+          - **Type:** $VERSION_TYPE
 
-### Changes
-- Updated \`package.json\` version
+          ### Changes
+          - Updated \`package.json\` version
 
-### After Merge
-This PR will automatically create:
-- Git tag \`v$NEW_VERSION\`
-- GitHub Release with generated notes"
+          ### After Merge
+          This PR will automatically create:
+          - Git tag \`v$NEW_VERSION\`
+          - GitHub Release with generated notes"

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -52,32 +52,32 @@ jobs:
           echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
           echo "branch_name=release/v$NEW_VERSION" >> $GITHUB_OUTPUT
 
-      - name: Create release branch
+      - name: Create release branch and PR
+        env:
+          BRANCH_NAME: ${{ steps.bump.outputs.branch_name }}
+          NEW_VERSION: ${{ steps.bump.outputs.new_version }}
+          VERSION_TYPE: ${{ github.event.inputs.version_type }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git checkout -b ${{ steps.bump.outputs.branch_name }}
-          git add package.json pnpm-lock.yaml
-          git commit -m "chore: bump version to ${{ steps.bump.outputs.new_version }}"
-          git push origin ${{ steps.bump.outputs.branch_name }}
+          git checkout -b "$BRANCH_NAME"
+          git add package.json
+          git commit -m "chore: bump version to $NEW_VERSION"
+          git push origin "$BRANCH_NAME"
 
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@4e1beaa7521e8b457b572c090b25bd3db56bf1c5 # v5
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ steps.bump.outputs.branch_name }}
-          title: 'chore: bump version to ${{ steps.bump.outputs.new_version }}'
-          body: |
-            ## Version Bump
+          # Create PR using GitHub CLI
+          gh pr create \
+            --base main \
+            --head "$BRANCH_NAME" \
+            --title "chore: bump version to $NEW_VERSION" \
+            --body "## Version Bump
 
-            - **Version:** ${{ steps.bump.outputs.new_version }}
-            - **Type:** ${{ github.event.inputs.version_type }}
+- **Version:** $NEW_VERSION
+- **Type:** $VERSION_TYPE
 
-            ### Changes
-            - Updated `package.json` version
-            - Updated `pnpm-lock.yaml`
+### Changes
+- Updated \`package.json\` version
 
-            ### After Merge
-            This PR will automatically create:
-            - Git tag `v${{ steps.bump.outputs.new_version }}`
-            - GitHub Release with generated notes
-          base: main
-          delete-branch: true
+### After Merge
+This PR will automatically create:
+- Git tag \`v$NEW_VERSION\`
+- GitHub Release with generated notes"

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -29,18 +29,23 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Configure Git
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: 10.33.2
+
       - name: Bump version
         id: bump
         run: |
           # Bump version without creating git tag
-          npm version ${{ github.event.inputs.version_type }} --no-git-tag-version
+          pnpm version ${{ github.event.inputs.version_type }} --no-git-tag-version
 
           # Get new version
           NEW_VERSION=$(node -p "require('./package.json').version")
@@ -50,7 +55,7 @@ jobs:
       - name: Create release branch
         run: |
           git checkout -b ${{ steps.bump.outputs.branch_name }}
-          git add package.json package-lock.json
+          git add package.json pnpm-lock.yaml
           git commit -m "chore: bump version to ${{ steps.bump.outputs.new_version }}"
           git push origin ${{ steps.bump.outputs.branch_name }}
 
@@ -68,7 +73,7 @@ jobs:
 
             ### Changes
             - Updated `package.json` version
-            - Updated `package-lock.json`
+            - Updated `pnpm-lock.yaml`
 
             ### After Merge
             This PR will automatically create:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,56 @@
+name: Release Workflow
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  create-release:
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from branch name
+        id: extract_version
+        run: |
+          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
+          VERSION=${BRANCH_NAME#release/v}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag_name=v$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '20'
+
+      - name: Get version from package.json
+        id: package_version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Create and push tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "${{ steps.extract_version.outputs.tag_name }}" -m "Release ${{ steps.extract_version.outputs.tag_name }}"
+          git push origin "${{ steps.extract_version.outputs.tag_name }}"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
+        with:
+          tag_name: ${{ steps.extract_version.outputs.tag_name }}
+          name: Release ${{ steps.extract_version.outputs.tag_name }}
+          generate_release_notes: true
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,9 @@ jobs:
 
       - name: Extract version from branch name
         id: extract_version
+        env:
+          BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
         run: |
-          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
           VERSION=${BRANCH_NAME#release/v}
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "tag_name=v$VERSION" >> $GITHUB_OUTPUT
@@ -32,9 +33,10 @@ jobs:
           node-version: '24'
 
       - name: Verify version consistency
+        env:
+          BRANCH_VERSION: ${{ steps.extract_version.outputs.version }}
         run: |
           PKG_VERSION=$(node -p "require('./package.json').version")
-          BRANCH_VERSION="${{ steps.extract_version.outputs.version }}"
           if [ "$PKG_VERSION" != "$BRANCH_VERSION" ]; then
             echo "Error: Version mismatch!"
             echo "Branch version: $BRANCH_VERSION"
@@ -44,11 +46,13 @@ jobs:
           echo "Version verified: $PKG_VERSION"
 
       - name: Create and push tag
+        env:
+          TAG_NAME: ${{ steps.extract_version.outputs.tag_name }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "${{ steps.extract_version.outputs.tag_name }}" -m "Release ${{ steps.extract_version.outputs.tag_name }}"
-          git push origin "${{ steps.extract_version.outputs.tag_name }}"
+          git tag -a "$TAG_NAME" -m "Release $TAG_NAME"
+          git push origin "$TAG_NAME"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
@@ -58,5 +62,4 @@ jobs:
           generate_release_notes: true
           draft: false
           prerelease: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,13 +29,19 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: '20'
+          node-version: '24'
 
-      - name: Get version from package.json
-        id: package_version
+      - name: Verify version consistency
         run: |
-          VERSION=$(node -p "require('./package.json').version")
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          BRANCH_VERSION="${{ steps.extract_version.outputs.version }}"
+          if [ "$PKG_VERSION" != "$BRANCH_VERSION" ]; then
+            echo "Error: Version mismatch!"
+            echo "Branch version: $BRANCH_VERSION"
+            echo "Package.json version: $PKG_VERSION"
+            exit 1
+          fi
+          echo "Version verified: $PKG_VERSION"
 
       - name: Create and push tag
         run: |


### PR DESCRIPTION
## 概要

package.jsonのバージョン更新とtag/release作成を自動化するGitHub Actionsワークフローを追加します。

## 変更内容

### 新規ワークフロー

1. **bump-version.yml** - 手動実行ワークフロー
   - GitHub Actionsタブから `patch` / `minor` / `major` を選択して実行
   - `release/vX.X.X` ブランチを作成し、PRを自動生成
   - コミットハッシュ固定済みの安全なアクション使用

2. **release.yml** - 自動実行ワークフロー
   - `release/v*` ブランチのPRがmainにマージされると自動実行
   - git tagを作成・プッシュ
   - GitHub Releaseを自動生成（リリースノート付き）

## セキュリティ対策

全てのGitHub Actionsを特定のコミットハッシュに固定：

| アクション | コミットハッシュ | バージョン |
|-----------|-----------------|-----------|
| actions/checkout | `34e114876b0b11c390a56381ad16ebd13914f8d5` | v4 |
| actions/setup-node | `49933ea5288caeca8642d1e84afbd3f7d6820020` | v4 |
| softprops/action-gh-release | `de2c0eb89ae2a093876385947365aca7b0e5f844` | v1 |
| peter-evans/create-pull-request | `4e1beaa7521e8b457b572c090b25bd3db56bf1c5` | v5 |

## 使い方

1. GitHub Actions → Bump Version → Run workflow → patch/minor/major選択
2. 作成されたPRをレビュー・マージ
3. 自動的にtagとreleaseが作成される

## 注意点

mainブランチへの直接pushは不要になります。