### PR TITLE
fix: block Flow tab submission without playback position

### DIFF
--- a/e2e/comment-flow.test.ts
+++ b/e2e/comment-flow.test.ts
@@ -46,6 +46,11 @@ test.describe('Comment flow', () => {
     await page.waitForLoadState('networkidle');
     await simulateLogin(page);
 
+    // Use Shout tab to bypass position requirement
+    const shoutTab = page.getByRole('button', { name: /📢/ });
+    await expect(shoutTab).toBeVisible({ timeout: 10_000 });
+    await shoutTab.click();
+
     const textarea = page.locator('textarea');
     await expect(textarea).toBeVisible({ timeout: 10_000 });
 

--- a/e2e/comment-form-details.test.ts
+++ b/e2e/comment-form-details.test.ts
@@ -72,6 +72,9 @@ test.describe('Comment form — submit behavior', () => {
     await page.waitForLoadState('networkidle');
     await simulateLogin(page);
 
+    // Use Shout tab to bypass position requirement
+    await page.locator('button').filter({ hasText: /📢/ }).first().click();
+
     const textarea = page.locator('textarea');
     await expect(textarea).toBeVisible({ timeout: 10_000 });
     await textarea.fill('Ctrl+Enter test');
@@ -102,6 +105,9 @@ test.describe('Comment form — submit behavior', () => {
     await page.waitForLoadState('networkidle');
     await simulateLogin(page);
 
+    // Use Shout tab to bypass position requirement
+    await page.locator('button').filter({ hasText: /📢/ }).first().click();
+
     const textarea = page.locator('textarea');
     await expect(textarea).toBeVisible({ timeout: 10_000 });
     await textarea.fill('Double submit test');
@@ -129,6 +135,9 @@ test.describe('Comment form — submit behavior', () => {
       }
     }, TEST_RELAYS);
 
+    // Use Shout tab to bypass position requirement
+    await page.locator('button').filter({ hasText: /📢/ }).first().click();
+
     const textarea = page.locator('textarea');
     await expect(textarea).toBeVisible({ timeout: 10_000 });
     await textarea.fill('Will fail');
@@ -144,6 +153,9 @@ test.describe('Comment form — submit behavior', () => {
     await page.goto(TEST_TRACK_URL);
     await page.waitForLoadState('networkidle');
     await simulateLogin(page);
+
+    // Use Shout tab to bypass position requirement
+    await page.locator('button').filter({ hasText: /📢/ }).first().click();
 
     const textarea = page.locator('textarea');
     await expect(textarea).toBeVisible({ timeout: 10_000 });
@@ -392,6 +404,9 @@ test.describe('Comment form — CW empty reason', () => {
     await page.waitForLoadState('networkidle');
     await simulateLogin(page);
 
+    // Use Shout tab to bypass position requirement
+    await page.locator('button').filter({ hasText: /📢/ }).first().click();
+
     const textarea = page.locator('textarea');
     await expect(textarea).toBeVisible({ timeout: 10_000 });
 
@@ -430,6 +445,9 @@ test.describe('Comment form — network failure', () => {
         pool.relay(url).onEVENT((event: any) => ['OK', event.id, false, 'blocked']);
       }
     }, TEST_RELAYS);
+
+    // Use Shout tab to bypass position requirement
+    await page.locator('button').filter({ hasText: /📢/ }).first().click();
 
     const textarea = page.locator('textarea');
     await expect(textarea).toBeVisible({ timeout: 10_000 });

--- a/e2e/mobile-responsive.test.ts
+++ b/e2e/mobile-responsive.test.ts
@@ -97,6 +97,9 @@ test.describe('Mobile content page', () => {
     await page.waitForLoadState('networkidle');
     await simulateLogin(page);
 
+    // Use Shout tab to bypass position requirement
+    await page.locator('button').filter({ hasText: /📢/ }).first().click();
+
     const textarea = page.locator('textarea');
     await expect(textarea).toBeVisible({ timeout: 10_000 });
     await textarea.fill('Mobile comment');

--- a/e2e/multi-step-journeys.test.ts
+++ b/e2e/multi-step-journeys.test.ts
@@ -37,7 +37,8 @@ test.describe('User journeys', () => {
     await page.waitForLoadState('networkidle');
     await simulateLogin(page);
 
-    // 4. Post a comment
+    // 4. Post a comment (use Shout tab to bypass position requirement)
+    await page.locator('button').filter({ hasText: /📢/ }).first().click();
     const textarea = page.locator('textarea');
     await expect(textarea).toBeVisible({ timeout: 10_000 });
     await textarea.fill('My first comment!');

--- a/e2e/security.test.ts
+++ b/e2e/security.test.ts
@@ -195,6 +195,9 @@ test.describe('Private key detection', () => {
     await page.waitForLoadState('networkidle');
     await simulateLogin(page);
 
+    // Use Shout tab to bypass position requirement
+    await page.locator('button').filter({ hasText: /📢/ }).first().click();
+
     const textarea = page.locator('textarea');
     await expect(textarea).toBeVisible({ timeout: 10_000 });
 

--- a/e2e/timing-concurrent.test.ts
+++ b/e2e/timing-concurrent.test.ts
@@ -212,6 +212,9 @@ test.describe('Cross-feature: comment retry after failure', () => {
     await page.waitForLoadState('networkidle');
     await simulateLogin(page);
 
+    // Use Shout tab to bypass position requirement
+    await page.locator('button').filter({ hasText: /📢/ }).first().click();
+
     // Configure relays to reject first
     await page.evaluate((relays: string[]) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/e2e/toast-confirm.test.ts
+++ b/e2e/toast-confirm.test.ts
@@ -31,6 +31,9 @@ test.describe('Toast notifications', () => {
     await page.waitForLoadState('networkidle');
     await simulateLogin(page);
 
+    // Use Shout tab to bypass position requirement
+    await page.locator('button').filter({ hasText: /📢/ }).first().click();
+
     const textarea = page.locator('textarea');
     await expect(textarea).toBeVisible({ timeout: 10_000 });
     await textarea.fill('Toast test comment');
@@ -46,6 +49,9 @@ test.describe('Toast notifications', () => {
     await page.goto(TEST_TRACK_URL);
     await page.waitForLoadState('networkidle');
     await simulateLogin(page);
+
+    // Use Shout tab to bypass position requirement
+    await page.locator('button').filter({ hasText: /📢/ }).first().click();
 
     const textarea = page.locator('textarea');
     await expect(textarea).toBeVisible({ timeout: 10_000 });
@@ -128,6 +134,9 @@ test.describe('Toast — failure and manual close', () => {
     await page.waitForLoadState('networkidle');
     await simulateLogin(page);
 
+    // Use Shout tab to bypass position requirement
+    await page.locator('button').filter({ hasText: /📢/ }).first().click();
+
     // Configure relays to reject
     await page.evaluate((relays: string[]) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -183,6 +192,9 @@ test.describe('Toast — failure and manual close', () => {
     await page.goto(TEST_TRACK_URL);
     await page.waitForLoadState('networkidle');
     await simulateLogin(page);
+
+    // Use Shout tab to bypass position requirement
+    await page.locator('button').filter({ hasText: /📢/ }).first().click();
 
     const textarea = page.locator('textarea');
     await expect(textarea).toBeVisible({ timeout: 10_000 });

--- a/src/features/comments/ui/comment-form-view-model.svelte.ts
+++ b/src/features/comments/ui/comment-form-view-model.svelte.ts
@@ -2,7 +2,6 @@ import { neventEncode } from '@auftakt/core';
 
 import { getAuth } from '$shared/browser/auth.js';
 import { getPlayer } from '$shared/browser/player.js';
-import { toastError } from '$shared/browser/toast.js';
 import type { ContentId, ContentProvider } from '$shared/content/types.js';
 import { t } from '$shared/i18n/t.js';
 import { containsPrivateKey } from '$shared/nostr/content-parser.js';
@@ -19,7 +18,12 @@ interface CommentFormViewModelOptions {
   getActiveTab?: () => 'flow' | 'shout' | 'info';
 }
 
-export type CommentSubmitResult = 'sent' | 'failed' | 'skipped';
+export type CommentSubmitResult =
+  | 'sent'
+  | 'failed'
+  | 'skipped'
+  | 'position_required'
+  | 'private_key_blocked';
 
 export function createCommentFormViewModel(options: CommentFormViewModelOptions) {
   const auth = getAuth();
@@ -54,8 +58,11 @@ export function createCommentFormViewModel(options: CommentFormViewModelOptions)
     if (!trimmed || !auth.loggedIn) return 'skipped';
 
     if (containsPrivateKey(trimmed)) {
-      toastError(t('comment.error.contains_private_key'));
-      return 'failed';
+      return 'private_key_blocked';
+    }
+
+    if ((options.getActiveTab?.() ?? 'flow') === 'flow' && !hasPosition) {
+      return 'position_required';
     }
 
     flying = true;

--- a/src/features/comments/ui/comment-form-view-model.test.ts
+++ b/src/features/comments/ui/comment-form-view-model.test.ts
@@ -207,6 +207,42 @@ describe('createCommentFormViewModel', () => {
       expect(sendCommentMock).not.toHaveBeenCalled();
     });
 
+    it('returns position_required when flow tab has no position', async () => {
+      playerState.position = 0;
+      const vm = createCommentFormViewModel({
+        getContentId: () => contentId,
+        getProvider: () => provider,
+        getActiveTab: () => 'flow'
+      });
+      vm.content = 'hello';
+
+      const result = await vm.submit();
+
+      expect(result).toBe('position_required');
+      expect(sendCommentMock).not.toHaveBeenCalled();
+    });
+
+    it('allows submit when shout tab has no position', async () => {
+      playerState.position = 0;
+      const vm = createCommentFormViewModel({
+        getContentId: () => contentId,
+        getProvider: () => provider,
+        getActiveTab: () => 'shout'
+      });
+      vm.content = 'hello';
+
+      const submitPromise = vm.submit();
+      await vi.runAllTimersAsync();
+      const result = await submitPromise;
+
+      expect(result).toBe('sent');
+      expect(sendCommentMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          positionMs: undefined
+        })
+      );
+    });
+
     it('calls sendComment with trimmed content and positionMs when effectiveAttach=true', async () => {
       playerState.position = 15_000;
       const vm = makeVm();

--- a/src/lib/components/CommentForm.svelte
+++ b/src/lib/components/CommentForm.svelte
@@ -84,6 +84,14 @@
       toastSuccess(t('toast.comment_sent'));
       return;
     }
+    if (result === 'position_required') {
+      toastError(t('comment.error.position_required'));
+      return;
+    }
+    if (result === 'private_key_blocked') {
+      toastError(t('comment.error.contains_private_key'));
+      return;
+    }
     if (result === 'failed') {
       toastError(t('toast.comment_failed'));
     }

--- a/src/shared/i18n/de.json
+++ b/src/shared/i18n/de.json
@@ -220,6 +220,7 @@
   "toast.delete_failed": "Kommentar konnte nicht gelöscht werden",
   "toast.dismiss": "Schließen",
   "comment.error.contains_private_key": "Dein Kommentar enthält einen privaten Schlüssel (nsec). Aus Sicherheitsgründen blockiert.",
+  "comment.error.position_required": "Starte die Wiedergabe, um einen Flow-Kommentar hinzuzufügen.",
   "quote.loading": "Laden…",
   "quote.not_found": "Zitiertes Ereignis nicht gefunden",
   "quote.title": "Zitat",

--- a/src/shared/i18n/en.json
+++ b/src/shared/i18n/en.json
@@ -214,6 +214,7 @@
   "toast.delete_failed": "Failed to delete comment",
   "toast.dismiss": "Dismiss",
   "comment.error.contains_private_key": "Your comment contains a private key (nsec). Blocked for security.",
+  "comment.error.position_required": "Start playback to add a flow comment.",
   "quote.loading": "Loading…",
   "quote.not_found": "Quoted event not found",
   "quote.title": "Quote",

--- a/src/shared/i18n/es.json
+++ b/src/shared/i18n/es.json
@@ -220,6 +220,7 @@
   "toast.delete_failed": "Error al eliminar el comentario",
   "toast.dismiss": "Cerrar",
   "comment.error.contains_private_key": "Tu comentario contiene una clave privada (nsec). Bloqueado por seguridad.",
+  "comment.error.position_required": "Inicia la reproducción para añadir un comentario flow.",
   "quote.loading": "Cargando…",
   "quote.not_found": "Evento citado no encontrado",
   "quote.title": "Cita",

--- a/src/shared/i18n/fr.json
+++ b/src/shared/i18n/fr.json
@@ -220,6 +220,7 @@
   "toast.delete_failed": "Échec de la suppression du commentaire",
   "toast.dismiss": "Fermer",
   "comment.error.contains_private_key": "Votre commentaire contient une clé privée (nsec). Bloqué pour des raisons de sécurité.",
+  "comment.error.position_required": "Lancez la lecture pour ajouter un commentaire flow.",
   "quote.loading": "Chargement…",
   "quote.not_found": "Événement cité introuvable",
   "quote.title": "Citation",

--- a/src/shared/i18n/ja.json
+++ b/src/shared/i18n/ja.json
@@ -214,6 +214,7 @@
   "toast.delete_failed": "コメントの削除に失敗しました",
   "toast.dismiss": "閉じる",
   "comment.error.contains_private_key": "秘密鍵 (nsec) が含まれています。安全のため投稿をブロックしました。",
+  "comment.error.position_required": "再生を開始してからフローコメントを投稿してください。",
   "quote.loading": "読み込み中…",
   "quote.not_found": "引用元が見つかりません",
   "quote.title": "引用",

--- a/src/shared/i18n/ja_kyoto.json
+++ b/src/shared/i18n/ja_kyoto.json
@@ -214,6 +214,7 @@
   "toast.delete_failed": "コメント削除できまへんどした",
   "toast.dismiss": "閉じますえ",
   "comment.error.contains_private_key": "秘密鍵が含まれてますえ。安全のため投稿止めましたえ",
+  "comment.error.position_required": "再生してからフローコメント残しとくれやす。",
   "quote.loading": "読み込み中…",
   "quote.not_found": "引用元が見つかりません",
   "quote.title": "引用",

--- a/src/shared/i18n/ja_osaka.json
+++ b/src/shared/i18n/ja_osaka.json
@@ -220,6 +220,7 @@
   "toast.delete_failed": "コメントの削除でけへんかったわ",
   "toast.dismiss": "閉じるで",
   "comment.error.contains_private_key": "秘密鍵 (nsec) が入っとるで。安全のために投稿ブロックしたったわ。",
+  "comment.error.position_required": "再生してからフローコメント投稿してや。",
   "quote.loading": "読み込み中やで…",
   "quote.not_found": "引用元見つからへんわ",
   "quote.title": "引用",

--- a/src/shared/i18n/ja_villainess.json
+++ b/src/shared/i18n/ja_villainess.json
@@ -214,6 +214,7 @@
   "toast.delete_failed": "コメントの削除に失敗いたしましたわ",
   "toast.dismiss": "お閉じなさいませ",
   "comment.error.contains_private_key": "秘密鍵が含まれておりますわ。安全のため投稿をお止めいたしましたわ",
+  "comment.error.position_required": "再生してからフローコメントをお残しなさいませ。",
   "quote.loading": "読み込み中…",
   "quote.not_found": "引用元が見つかりません",
   "quote.title": "引用",

--- a/src/shared/i18n/ko.json
+++ b/src/shared/i18n/ko.json
@@ -220,6 +220,7 @@
   "toast.delete_failed": "댓글 삭제에 실패했습니다",
   "toast.dismiss": "닫기",
   "comment.error.contains_private_key": "댓글에 개인키(nsec)가 포함되어 있습니다. 보안을 위해 차단되었습니다.",
+  "comment.error.position_required": "플로우 댓글을 추가하려면 재생을 시작하세요.",
   "quote.loading": "로딩 중…",
   "quote.not_found": "인용된 이벤트를 찾을 수 없음",
   "quote.title": "인용",

--- a/src/shared/i18n/pt_br.json
+++ b/src/shared/i18n/pt_br.json
@@ -220,6 +220,7 @@
   "toast.delete_failed": "Falha ao excluir comentário",
   "toast.dismiss": "Fechar",
   "comment.error.contains_private_key": "Seu comentário contém uma chave privada (nsec). Bloqueado por segurança.",
+  "comment.error.position_required": "Inicie a reprodução para adicionar um comentário flow.",
   "quote.loading": "Carregando…",
   "quote.not_found": "Evento citado não encontrado",
   "quote.title": "Citação",

--- a/src/shared/i18n/zh_cn.json
+++ b/src/shared/i18n/zh_cn.json
@@ -220,6 +220,7 @@
   "toast.delete_failed": "评论删除失败",
   "toast.dismiss": "关闭",
   "comment.error.contains_private_key": "你的评论包含私钥（nsec）。出于安全考虑已阻止发布。",
+  "comment.error.position_required": "开始播放以添加时间线评论。",
   "quote.loading": "加载中…",
   "quote.not_found": "未找到引用的事件",
   "quote.title": "引用",


### PR DESCRIPTION
## 問題

Flowタブで再生時間が"--:--"（未再生）の時でも投稿ボタンが有効になっていた。

仕様では「Flow タブ + 再生前」は「送信時に「再生を開始してください」」とあるが、実装ではこのチェックが欠けていた。

## 修正内容

- submit() メソッドにFlowタブかつ hasPosition === false のチェックを追加
- エラー時は toastError で多言語メッセージを表示
- i18n: 11言語に comment.error.position_required を追加
- テスト: Flowタブ（位置なし）とShoutタブ（位置なし）の動作を検証するテストを追加

## 動作確認

- [x] 単体テスト: 26 tests passed
- [x] comments UI テスト: 182 tests passed  
- [x] 型チェック: 0 errors

## 仕様該当箇所

docs/superpowers/specs/2026-03-26-comment-ui-redesign.md 134行目
