### PR TITLE
test: cover late older relay list arrivals

### DIFF
--- a/packages/adapter-dexie/src/materialization.contract.test.ts
+++ b/packages/adapter-dexie/src/materialization.contract.test.ts
@@ -490,6 +490,40 @@ describe('Dexie NIP-62 request to vanish materialization', () => {
 });
 
 describe('Dexie replaceable materialization', () => {
+  it('keeps newer kind10002 relay list head when an older relay list arrives late', async () => {
+    const store = await createDexieEventStore({
+      dbName: `auftakt-dexie-relay-list-late-older-${Date.now()}-${Math.random()}`
+    });
+
+    await expect(
+      store.putWithReconcile(
+        event('new-relay-list', {
+          pubkey: 'alice',
+          created_at: 1000,
+          kind: 10002,
+          tags: [['r', 'wss://new.example.test']]
+        })
+      )
+    ).resolves.toMatchObject({ stored: true });
+
+    await expect(
+      store.putWithReconcile(
+        event('old-relay-list', {
+          pubkey: 'alice',
+          created_at: 500,
+          kind: 10002,
+          tags: [['r', 'wss://old.example.test']]
+        })
+      )
+    ).resolves.toMatchObject({ stored: false });
+
+    await expect(store.getReplaceableHead('alice', 10002, '')).resolves.toMatchObject({
+      id: 'new-relay-list',
+      tags: [['r', 'wss://new.example.test']]
+    });
+    await expect(store.getById('old-relay-list')).resolves.toBeNull();
+  });
+
   it('keeps newest replaceable head by pubkey and kind', async () => {
     const store = await createDexieEventStore({
       dbName: 'auftakt-dexie-replaceable'

--- a/packages/runtime/src/cached-read.contract.test.ts
+++ b/packages/runtime/src/cached-read.contract.test.ts
@@ -1,7 +1,7 @@
 import { finalizeEvent } from '@auftakt/core';
 import { describe, expect, it, vi } from 'vitest';
 
-import { cachedFetchById } from './cached-read.js';
+import { cachedFetchById, useCachedLatest } from './cached-read.js';
 
 const RELAY_SECRET_KEY = new Uint8Array(32).fill(7);
 
@@ -56,5 +56,75 @@ describe('@auftakt/runtime cached by-id reads', () => {
       content: 'from relay fallback'
     });
     expect(emitted).toEqual([{ ids: [relayEvent.id] }]);
+  });
+});
+
+describe('@auftakt/runtime cached latest reads', () => {
+  it('keeps newer kind10002 relay list when an older relay event arrives late', async () => {
+    const newerRelayList = finalizeEvent(
+      {
+        kind: 10002,
+        content: '',
+        tags: [['r', 'wss://new.example.test']],
+        created_at: 1000
+      },
+      RELAY_SECRET_KEY
+    );
+    const olderRelayList = finalizeEvent(
+      {
+        kind: 10002,
+        content: '',
+        tags: [['r', 'wss://old.example.test']],
+        created_at: 500
+      },
+      RELAY_SECRET_KEY
+    );
+    const emitted: unknown[] = [];
+    const runtime = {
+      getEventsDB: vi.fn(async () => ({
+        getById: vi.fn(async () => null),
+        getByPubkeyAndKind: vi.fn(async () => newerRelayList),
+        put: vi.fn(async () => true),
+        putWithReconcile: vi.fn(async (candidate: typeof newerRelayList) => ({
+          stored: candidate.created_at > 500
+        }))
+      })),
+      async getRelaySession() {
+        return {
+          use() {
+            return {
+              subscribe(observer: {
+                next?: (packet: { event?: unknown; from?: string }) => void;
+                complete?: () => void;
+              }) {
+                queueMicrotask(() => {
+                  observer.next?.({ event: olderRelayList, from: 'wss://old-relay.example.test' });
+                  observer.complete?.();
+                });
+                return { unsubscribe() {} };
+              }
+            };
+          }
+        };
+      },
+      createBackwardReq() {
+        return {
+          emit(input: unknown) {
+            emitted.push(input);
+          },
+          over() {}
+        };
+      }
+    };
+
+    const driver = useCachedLatest<typeof newerRelayList>(runtime, newerRelayList.pubkey, 10002);
+
+    await vi.waitFor(() => {
+      expect(driver.getSnapshot().event?.tags).toEqual([['r', 'wss://new.example.test']]);
+      expect(driver.getSnapshot().settlement.phase).toBe('settled');
+    });
+
+    expect(emitted).toEqual([{ kinds: [10002], authors: [newerRelayList.pubkey], limit: 1 }]);
+    driver.destroy();
   });
 });

--- a/packages/runtime/src/event-coordinator.contract.test.ts
+++ b/packages/runtime/src/event-coordinator.contract.test.ts
@@ -486,6 +486,52 @@ describe('EventCoordinator read policy', () => {
     });
   });
 
+  it('does not return a late older kind10002 relay candidate after newer local materialization', async () => {
+    const newerRelayList = {
+      id: 'new-relay-list',
+      pubkey: 'alice',
+      created_at: 1000,
+      kind: 10002,
+      tags: [['r', 'wss://new.example.test']],
+      content: ''
+    };
+    const olderRelayList = {
+      id: 'old-relay-list',
+      pubkey: 'alice',
+      created_at: 500,
+      kind: 10002,
+      tags: [['r', 'wss://old.example.test']],
+      content: ''
+    };
+    const putWithReconcile = vi.fn(async (candidate: typeof newerRelayList) => ({
+      stored: candidate.created_at > 500
+    }));
+    const coordinator = createEventCoordinator({
+      relayGateway: {
+        verify: vi.fn(async () => ({
+          strategy: 'fallback-req' as const,
+          candidates: [{ event: { raw: 'late-old' }, relayUrl: 'wss://old-relay.example.test' }]
+        }))
+      },
+      ingestRelayCandidate: vi.fn(async () => ({ ok: true as const, event: olderRelayList })),
+      store: {
+        getById: vi.fn(async () => null),
+        getAllByKind: vi.fn(async () => [newerRelayList]),
+        putWithReconcile
+      },
+      relay: { verify: vi.fn(async () => []) }
+    });
+
+    const result = await coordinator.read(
+      { authors: ['alice'], kinds: [10002], limit: 1 },
+      { policy: 'relayConfirmed' }
+    );
+
+    expect(result.events).toEqual([newerRelayList]);
+    expect(result.events[0]?.tags).toEqual([['r', 'wss://new.example.test']]);
+    expect(putWithReconcile).toHaveBeenCalledWith(olderRelayList);
+  });
+
   it('coalesces duplicate gateway candidates while materialization is in flight', async () => {
     const remote = {
       id: 'dupe',

--- a/packages/runtime/src/hot-event-index.contract.test.ts
+++ b/packages/runtime/src/hot-event-index.contract.test.ts
@@ -84,6 +84,32 @@ describe('HotEventIndex', () => {
     expect(index.getById('old-emoji')).toBeNull();
   });
 
+  it('keeps newer hot kind10002 relay list head when an older relay list arrives late', () => {
+    const index = createHotEventIndex();
+    index.applyVisible(
+      event('new-relay-list', {
+        pubkey: 'alice',
+        kind: 10002,
+        created_at: 1000,
+        tags: [['r', 'wss://new.example.test']]
+      })
+    );
+    index.applyVisible(
+      event('old-relay-list', {
+        pubkey: 'alice',
+        kind: 10002,
+        created_at: 500,
+        tags: [['r', 'wss://old.example.test']]
+      })
+    );
+
+    expect(index.getReplaceableHead('alice', 10002)).toMatchObject({
+      id: 'new-relay-list',
+      tags: [['r', 'wss://new.example.test']]
+    });
+    expect(index.getById('old-relay-list')).toBeNull();
+  });
+
   it('removes deleted events from all hot indexes', () => {
     const index = createHotEventIndex();
     index.applyVisible(

--- a/src/features/relays/ui/relay-settings-view-model.test.ts
+++ b/src/features/relays/ui/relay-settings-view-model.test.ts
@@ -299,6 +299,25 @@ describe('createRelaySettingsViewModel', () => {
       ).toBe('loaded');
     });
 
+    it('treats the settled newer kind10002 relay list as loaded after a late older candidate is ignored upstream', () => {
+      expect(
+        resolveRelayListLoadState(
+          {
+            event: {
+              id: 'new-relay-list',
+              pubkey: 'pubkey-a',
+              created_at: 1000,
+              kind: 10002,
+              tags: [['r', 'wss://new.example.test']],
+              content: ''
+            },
+            settlement: { phase: 'settled', provenance: 'relay', reason: 'cache-hit' }
+          },
+          1
+        )
+      ).toBe('loaded');
+    });
+
     it('returns no-list for settled miss with no event and empty entries', () => {
       expect(
         resolveRelayListLoadState(

--- a/src/shared/browser/relays-fetch.test.ts
+++ b/src/shared/browser/relays-fetch.test.ts
@@ -89,6 +89,23 @@ describe('fetchRelayList', () => {
     });
   });
 
+  it('keeps newer kind10002 entries when an older relay-list event is returned after it', async () => {
+    fetchRelayListSourcesMock.mockResolvedValueOnce({
+      relayListEvents: [
+        { created_at: 1000, tags: [['r', 'wss://new.example.test']] },
+        { created_at: 500, tags: [['r', 'wss://old.example.test']] }
+      ],
+      followListEvents: []
+    });
+
+    const result = await fetchRelayList(PUBKEY);
+
+    expect(result).toEqual({
+      source: 'kind10002',
+      entries: [{ url: 'wss://new.example.test', read: true, write: true }]
+    });
+  });
+
   it('keeps kind10002 as the consumed read source when kind3 also exists', async () => {
     fetchRelayListSourcesMock.mockResolvedValueOnce({
       relayListEvents: [{ created_at: 1000, tags: [['r', 'wss://primary.relay.com']] }],


### PR DESCRIPTION
## Summary
- Add storage, runtime, and relay-settings guard coverage for late-arriving older kind:10002 relay-list events.
- Confirm newer replaceable heads remain visible across Dexie materialization, hot index, coordinator, cached latest, and UI selection.
- Preserve kind:10002 priority over kind:3 fallback behavior.

## Verification
- pnpm exec vitest run packages/adapter-dexie/src/materialization.contract.test.ts packages/runtime/src/hot-event-index.contract.test.ts packages/runtime/src/event-coordinator.contract.test.ts packages/runtime/src/cached-read.contract.test.ts src/shared/browser/relays-fetch.test.ts src/features/relays/ui/relay-settings-view-model.test.ts
- pnpm run check