### PR TITLE
[codex] fix custom emoji picker refresh

### DIFF
--- a/src/lib/components/EmojiPicker.svelte
+++ b/src/lib/components/EmojiPicker.svelte
@@ -3,8 +3,10 @@
 
   import { extractShortcode } from '$shared/auftakt/resonote.js';
   import { getEmojiMartModules } from '$shared/browser/emoji-mart.js';
-  import { type EmojiCategory, getCustomEmojis } from '$shared/browser/emoji-sets.js';
+  import { getCustomEmojis } from '$shared/browser/emoji-sets.js';
   import { getLocale } from '$shared/browser/locale.js';
+
+  import { createEmojiPickerMountAction } from './emoji-picker-mount.js';
 
   interface Props {
     onSelect: (reaction: string, emojiUrl?: string) => void;
@@ -29,34 +31,15 @@
     }
   }
 
-  const mountPicker: Action<HTMLDivElement, EmojiCategory[]> = (node, custom) => {
-    let mounted = true;
-
-    (async () => {
-      const { data, Picker } = await getEmojiMartModules();
-
-      if (!mounted) return;
-
-      const PickerClass = Picker as new (opts: Record<string, unknown>) => HTMLElement;
-      const picker = new PickerClass({
-        data,
-        custom: custom.length > 0 ? custom : undefined,
-        theme: 'dark',
-        locale: getLocale(),
-        previewPosition: 'none',
-        skinTonePosition: 'search',
-        onEmojiSelect: handleEmojiSelect
-      });
-
-      node.appendChild(picker);
-    })();
-
-    return {
-      destroy() {
-        mounted = false;
-      }
-    };
-  };
+  const mountPicker: Action<HTMLDivElement, typeof emojiSets.categories> =
+    createEmojiPickerMountAction({
+      getEmojiMartModules: async () => {
+        const { data, Picker } = await getEmojiMartModules();
+        return { data, Picker: Picker as new (opts: Record<string, unknown>) => HTMLElement };
+      },
+      getLocale,
+      onEmojiSelect: handleEmojiSelect
+    });
 </script>
 
 <div use:mountPicker={emojiSets.categories} class="emoji-picker-container"></div>

--- a/src/lib/components/emoji-picker-mount.test.ts
+++ b/src/lib/components/emoji-picker-mount.test.ts
@@ -66,7 +66,7 @@ describe('createEmojiPickerMountAction', () => {
       remove() {}
     }
 
-    let resolveModules: ((value: { data: unknown; Picker: typeof Picker }) => void) | null = null;
+    let resolveModules!: (value: { data: unknown; Picker: typeof Picker }) => void;
     const modulesPromise = new Promise<{ data: unknown; Picker: typeof Picker }>((resolve) => {
       resolveModules = resolve;
     });
@@ -81,7 +81,7 @@ describe('createEmojiPickerMountAction', () => {
     const custom = [category('custom-inline')];
     handle?.update?.(custom);
 
-    resolveModules?.({ data: { emojis: {} }, Picker });
+    resolveModules({ data: { emojis: {} }, Picker });
     await Promise.resolve();
 
     expect(appended).toHaveLength(1);

--- a/src/lib/components/emoji-picker-mount.test.ts
+++ b/src/lib/components/emoji-picker-mount.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { EmojiCategory } from '$shared/browser/emoji-sets.js';
+
+import { createEmojiPickerMountAction } from './emoji-picker-mount.js';
+
+function category(id: string): EmojiCategory {
+  return {
+    id,
+    name: id,
+    emojis: [{ id: 'wave', name: 'wave', skins: [{ src: 'https://example.com/wave.png' }] }]
+  };
+}
+
+describe('createEmojiPickerMountAction', () => {
+  it('空カテゴリで mount した後のカテゴリ更新を Picker に反映する', async () => {
+    const appended: unknown[] = [];
+    const removed: unknown[] = [];
+    const node = {
+      appendChild: vi.fn((child: unknown) => appended.push(child))
+    } as unknown as HTMLDivElement;
+
+    class Picker {
+      options: Record<string, unknown>;
+
+      constructor(options: Record<string, unknown>) {
+        this.options = options;
+      }
+
+      remove() {
+        removed.push(this);
+      }
+    }
+
+    const action = createEmojiPickerMountAction({
+      getEmojiMartModules: async () => ({ data: { emojis: {} }, Picker }),
+      getLocale: () => 'ja',
+      onEmojiSelect: vi.fn()
+    });
+
+    const handle = action(node, []);
+    await Promise.resolve();
+
+    const custom = [category('custom-inline')];
+    handle?.update?.(custom);
+    await Promise.resolve();
+
+    expect(appended).toHaveLength(2);
+    expect(removed).toEqual([appended[0]]);
+    expect((appended[1] as Picker).options.custom).toBe(custom);
+  });
+});

--- a/src/lib/components/emoji-picker-mount.test.ts
+++ b/src/lib/components/emoji-picker-mount.test.ts
@@ -49,4 +49,109 @@ describe('createEmojiPickerMountAction', () => {
     expect(removed).toEqual([appended[0]]);
     expect((appended[1] as Picker).options.custom).toBe(custom);
   });
+
+  it('モジュール読み込み前の update で渡したカテゴリを初回生成に反映する', async () => {
+    const appended: unknown[] = [];
+    const node = {
+      appendChild: vi.fn((child: unknown) => appended.push(child))
+    } as unknown as HTMLDivElement;
+
+    class Picker {
+      options: Record<string, unknown>;
+
+      constructor(options: Record<string, unknown>) {
+        this.options = options;
+      }
+
+      remove() {}
+    }
+
+    let resolveModules: ((value: { data: unknown; Picker: typeof Picker }) => void) | null = null;
+    const modulesPromise = new Promise<{ data: unknown; Picker: typeof Picker }>((resolve) => {
+      resolveModules = resolve;
+    });
+
+    const action = createEmojiPickerMountAction({
+      getEmojiMartModules: () => modulesPromise,
+      getLocale: () => 'ja',
+      onEmojiSelect: vi.fn()
+    });
+
+    const handle = action(node, []);
+    const custom = [category('custom-inline')];
+    handle?.update?.(custom);
+
+    resolveModules?.({ data: { emojis: {} }, Picker });
+    await Promise.resolve();
+
+    expect(appended).toHaveLength(1);
+    expect((appended[0] as Picker).options.custom).toBe(custom);
+  });
+
+  it('同じ内容のカテゴリ配列では Picker を再生成しない', async () => {
+    const appended: unknown[] = [];
+    const removed: unknown[] = [];
+    const node = {
+      appendChild: vi.fn((child: unknown) => appended.push(child))
+    } as unknown as HTMLDivElement;
+
+    class Picker {
+      options: Record<string, unknown>;
+
+      constructor(options: Record<string, unknown>) {
+        this.options = options;
+      }
+
+      remove() {
+        removed.push(this);
+      }
+    }
+
+    const action = createEmojiPickerMountAction({
+      getEmojiMartModules: async () => ({ data: { emojis: {} }, Picker }),
+      getLocale: () => 'ja',
+      onEmojiSelect: vi.fn()
+    });
+
+    const initial = [category('custom-inline')];
+    const handle = action(node, initial);
+    await Promise.resolve();
+
+    const equalButDifferentReference = [
+      {
+        ...initial[0],
+        emojis: initial[0].emojis.map((emoji) => ({
+          ...emoji,
+          skins: emoji.skins.map((skin) => ({ ...skin }))
+        }))
+      }
+    ];
+    handle?.update?.(equalButDifferentReference);
+    await Promise.resolve();
+
+    expect(appended).toHaveLength(1);
+    expect(removed).toHaveLength(0);
+  });
+
+  it('モジュール読み込み失敗時に例外を握り潰さずログ出力する', async () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const node = {
+      appendChild: vi.fn()
+    } as unknown as HTMLDivElement;
+
+    const action = createEmojiPickerMountAction({
+      getEmojiMartModules: async () => {
+        throw new Error('module load failed');
+      },
+      getLocale: () => 'ja',
+      onEmojiSelect: vi.fn()
+    });
+
+    action(node, []);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
 });

--- a/src/lib/components/emoji-picker-mount.ts
+++ b/src/lib/components/emoji-picker-mount.ts
@@ -1,0 +1,64 @@
+import type { Action } from 'svelte/action';
+
+import type { EmojiCategory } from '$shared/browser/emoji-sets.js';
+
+interface EmojiMartModules {
+  data: unknown;
+  Picker: new (opts: Record<string, unknown>) => { remove(): void };
+}
+
+interface EmojiPickerMountOptions {
+  getEmojiMartModules: () => Promise<EmojiMartModules>;
+  getLocale: () => string;
+  onEmojiSelect: (emoji: Record<string, unknown>) => void;
+}
+
+export function createEmojiPickerMountAction(
+  options: EmojiPickerMountOptions
+): Action<HTMLDivElement, EmojiCategory[]> {
+  return (node, initialCustom = []) => {
+    let mounted = true;
+    let custom = initialCustom;
+    let picker: { remove(): void } | null = null;
+    let modules: EmojiMartModules | null = null;
+
+    function removePicker() {
+      picker?.remove();
+      picker = null;
+    }
+
+    function appendPicker() {
+      if (!mounted || !modules) return;
+      removePicker();
+
+      const PickerClass = modules.Picker;
+      picker = new PickerClass({
+        data: modules.data,
+        custom: custom.length > 0 ? custom : undefined,
+        theme: 'dark',
+        locale: options.getLocale(),
+        previewPosition: 'none',
+        skinTonePosition: 'search',
+        onEmojiSelect: options.onEmojiSelect
+      });
+      node.appendChild(picker as unknown as Node);
+    }
+
+    void options.getEmojiMartModules().then((loaded) => {
+      modules = loaded;
+      appendPicker();
+    });
+
+    return {
+      update(nextCustom = []) {
+        if (nextCustom === custom) return;
+        custom = nextCustom;
+        appendPicker();
+      },
+      destroy() {
+        mounted = false;
+        removePicker();
+      }
+    };
+  };
+}

--- a/src/lib/components/emoji-picker-mount.ts
+++ b/src/lib/components/emoji-picker-mount.ts
@@ -1,6 +1,9 @@
 import type { Action } from 'svelte/action';
 
 import type { EmojiCategory } from '$shared/browser/emoji-sets.js';
+import { createLogger } from '$shared/utils/logger.js';
+
+const log = createLogger('emoji-picker-mount');
 
 interface EmojiMartModules {
   data: unknown;
@@ -11,6 +14,30 @@ interface EmojiPickerMountOptions {
   getEmojiMartModules: () => Promise<EmojiMartModules>;
   getLocale: () => string;
   onEmojiSelect: (emoji: Record<string, unknown>) => void;
+}
+
+function hasSameCustomCategories(
+  a: readonly EmojiCategory[],
+  b: readonly EmojiCategory[]
+): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) {
+    const left = a[i];
+    const right = b[i];
+    if (left.id !== right.id || left.name !== right.name) return false;
+    if (left.emojis.length !== right.emojis.length) return false;
+    for (let j = 0; j < left.emojis.length; j += 1) {
+      const leftEmoji = left.emojis[j];
+      const rightEmoji = right.emojis[j];
+      if (leftEmoji.id !== rightEmoji.id || leftEmoji.name !== rightEmoji.name) return false;
+      if (leftEmoji.skins.length !== rightEmoji.skins.length) return false;
+      for (let k = 0; k < leftEmoji.skins.length; k += 1) {
+        if (leftEmoji.skins[k]?.src !== rightEmoji.skins[k]?.src) return false;
+      }
+    }
+  }
+  return true;
 }
 
 export function createEmojiPickerMountAction(
@@ -44,14 +71,19 @@ export function createEmojiPickerMountAction(
       node.appendChild(picker as unknown as Node);
     }
 
-    void options.getEmojiMartModules().then((loaded) => {
-      modules = loaded;
-      appendPicker();
-    });
+    void options
+      .getEmojiMartModules()
+      .then((loaded) => {
+        modules = loaded;
+        appendPicker();
+      })
+      .catch((error: unknown) => {
+        log.error('Failed to load emoji mart modules', error);
+      });
 
     return {
       update(nextCustom = []) {
-        if (nextCustom === custom) return;
+        if (hasSameCustomCategories(nextCustom, custom)) return;
         custom = nextCustom;
         appendPicker();
       },


### PR DESCRIPTION
## Summary

- Rebuild the Emoji Mart picker when custom emoji categories change after the picker has mounted.
- Extract the picker mount/update behavior into a focused helper.
- Add a regression test for the empty-initial-categories then custom-categories-loaded path.

## Root cause

The post composer and picker read custom emoji categories from the shared emoji state, but the picker only applied the `custom` option during its initial mount. If the picker mounted before `loadCustomEmojis` completed, it stayed on the empty custom category set and never showed the loaded custom emojis.

## Impact

After custom emoji data loads, the composer emoji button can show the custom emoji set instead of remaining stuck on the initial empty state. The same shared categories are what the `:` autocomplete path uses for candidates.

## Validation

- `pnpm exec vitest run src/lib/components/emoji-picker-mount.test.ts src/shared/browser/emoji-sets.test.ts packages/resonote/src/custom-emoji.contract.test.ts`
- `pnpm exec eslint src/lib/components/EmojiPicker.svelte src/lib/components/emoji-picker-mount.ts src/lib/components/emoji-picker-mount.test.ts`
- `pnpm run check`