### PR TITLE
fix(ci): use GitHub App token for release tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,20 @@ jobs:
       contents: write
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        with:
+          app-id: ${{ secrets.CLAUDE_APP_ID }}
+          private-key: ${{ secrets.CLAUDE_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-workflows: write
+
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Extract version from branch name
         id: extract_version
@@ -62,4 +72,4 @@ jobs:
           generate_release_notes: true
           draft: false
           prerelease: false
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,6 @@ jobs:
           app-id: ${{ secrets.CLAUDE_APP_ID }}
           private-key: ${{ secrets.CLAUDE_APP_PRIVATE_KEY }}
           permission-contents: write
-          permission-workflows: write
 
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4


### PR DESCRIPTION
## Summary
- Generate a GitHub App installation token in the release workflow
- Use that token for checkout so `git push origin v*` is authenticated as the GitHub App instead of `GITHUB_TOKEN`
- Use the same token when creating the GitHub Release

## Why
Tag pushes made with the default `GITHUB_TOKEN` do not trigger subsequent workflows. Because production deploy is triggered by `push.tags: ['v*']`, the release workflow needs to push tags with a token that can trigger the CI workflow.

## Test plan
- Not run; workflow-only change
- Expected behavior: merging a `release/v*` PR creates a `v*` tag using the App token, which then triggers the CI workflow and production deploy job