### PR TITLE
fix: prevent markdown link javascript URL bypass in description rendering

### DIFF
--- a/src/shared/utils/html.test.ts
+++ b/src/shared/utils/html.test.ts
@@ -84,6 +84,16 @@ describe('renderMarkdown', () => {
     expect(result).not.toContain('javascript:');
   });
 
+  it('blocks obfuscated javascript: URLs with control characters', () => {
+    const result = renderMarkdown('[xss](java\tscript:alert(1))');
+    expect(result).not.toContain('href');
+  });
+
+  it('blocks data: URLs', () => {
+    const result = renderMarkdown('[xss](data:text/html;base64,PHNjcmlwdD4=)');
+    expect(result).not.toContain('href');
+  });
+
   it('escapes HTML in link text', () => {
     const result = renderMarkdown('[<script>](https://example.com)');
     expect(result).toContain('&lt;script&gt;');

--- a/src/shared/utils/html.ts
+++ b/src/shared/utils/html.ts
@@ -106,12 +106,22 @@ export function renderMarkdown(md: string): string {
   );
 }
 
-/** Check if a URL is safe (not javascript:, data:, vbscript:) */
+/** Check if a URL is safe for clickable links. */
 function isSafeUrl(url: string): boolean {
-  const lower = url.trim().toLowerCase();
-  return (
-    !lower.startsWith('javascript:') && !lower.startsWith('data:') && !lower.startsWith('vbscript:')
-  );
+  const trimmed = url.trim();
+  if (!trimmed) return false;
+
+  // Require an explicit scheme and canonicalize before protocol checks.
+  if (!/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(trimmed)) {
+    return false;
+  }
+
+  try {
+    const parsed = new URL(trimmed);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
 }
 
 /** Escape a string for use in an HTML attribute */


### PR DESCRIPTION
### Motivation
- Close a critical XSS regression where untrusted RSS/Nostr descriptions converted to Markdown could produce clickable anchors whose `href` was interpreted as `javascript:` after browser URL canonicalization (e.g. `java\tscript:` with embedded control characters). 

### Description
- Hardened `isSafeUrl` in `src/shared/utils/html.ts` to require an explicit scheme, canonicalize the URL with `new URL(...)`, and allow only `http:` and `https:` protocols. 
- Added a scheme-presence regex check to reject non-absolute/malformed links before parsing. 
- Kept existing `renderMarkdown` behavior (it still escapes raw HTML and constructs anchors), but now anchors are created only when `isSafeUrl` returns true. 
- Added regression tests in `src/shared/utils/html.test.ts` to cover obfuscated `javascript:` payloads and `data:` URLs to prevent reintroducing the bypass. 

### Testing
- Added unit tests to `src/shared/utils/html.test.ts` that assert `renderMarkdown` does not emit `href` for `javascript:` (including control-character-obfuscated variants) and `data:` URLs. 
- Attempted to run `pnpm vitest src/shared/utils/html.test.ts`, but the environment could not execute the suite because the repository requires Node `>=24.0.0` while the runtime provided Node `v20.20.2`, so tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11963b9b38832394e8058e3546ebd3)